### PR TITLE
feat: dynamically update README counts and FAA date after pipeline runs

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -121,3 +121,16 @@ jobs:
           echo "| Status | ${{ steps.pipeline.outputs.status }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Airports | ${{ steps.pipeline.outputs.airports_count }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Navaids | ${{ steps.pipeline.outputs.navaids_count }} |" >> $GITHUB_STEP_SUMMARY
+
+      - name: Commit updated README
+        if: steps.pipeline.outputs.status == 'success'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          if git diff --cached --quiet README.md; then
+            echo "No changes to README.md - skipping commit"
+          else
+            git commit -m "data: update README counts and FAA date"
+            git push
+          fi

--- a/R/scrape_airports_navaids.R
+++ b/R/scrape_airports_navaids.R
@@ -278,6 +278,7 @@ run_pipeline <- function(force = FALSE) {
   # Source the cleaning and push scripts (functions only, no execution)
   source("R/clean_data.R", local = FALSE)
   source("R/push_to_supabase.R", local = FALSE)
+  source("R/update_readme.R", local = FALSE)
 
   # Run data cleaning
   message("Running data cleaning...")
@@ -301,6 +302,9 @@ run_pipeline <- function(force = FALSE) {
   # Log to history file
 
   log_pipeline_history(current_date, result$airports_count, result$navaids_count)
+
+  # Update README with current data
+  update_readme(current_date, result$airports_count, result$navaids_count)
 
   message("Done! Data updated to ", format(current_date, "%d %b %Y"))
   result

--- a/R/update_readme.R
+++ b/R/update_readme.R
@@ -1,0 +1,61 @@
+# update_readme.R
+# Updates README.md with current pipeline data (counts and FAA date)
+
+library(checkmate)
+
+#' Update README.md with current pipeline data
+#'
+#' Replaces marker-delimited values in README.md with current counts
+#' and FAA subscription date. Markers use the format:
+#' `<!-- pipeline:key -->value<!-- /pipeline:key -->`
+#'
+#' @param faa_date Date object: FAA subscription effective date
+#' @param airports_count Integer: number of airports
+#' @param navaids_count Integer: number of navaids
+#' @param readme_path Character: path to README.md (default: "README.md")
+#' @return Logical TRUE if README was modified, FALSE if unchanged
+#' @export
+update_readme <- function(faa_date,
+                          airports_count,
+                          navaids_count,
+                          readme_path = "README.md") {
+  checkmate::assert_date(faa_date, len = 1)
+  checkmate::assert_integerish(airports_count, lower = 0, len = 1)
+  checkmate::assert_integerish(navaids_count, lower = 0, len = 1)
+  checkmate::assert_file_exists(readme_path)
+
+  original_text <- readLines(readme_path, warn = FALSE)
+  content <- paste(original_text, collapse = "\n")
+
+  # Build replacements: marker key -> formatted value
+  replacements <- list(
+    faa_date = format(faa_date, "%Y-%m-%d"),
+    airports_count = trimws(format(airports_count, big.mark = ",")),
+    navaids_count = trimws(format(navaids_count, big.mark = ","))
+  )
+
+  for (key in names(replacements)) {
+    pattern <- paste0(
+      "<!-- pipeline:", key, " -->",
+      ".*?",
+      "<!-- /pipeline:", key, " -->"
+    )
+    replacement <- paste0(
+      "<!-- pipeline:", key, " -->",
+      replacements[[key]],
+      "<!-- /pipeline:", key, " -->"
+    )
+    content <- gsub(pattern, replacement, content, perl = TRUE)
+  }
+
+  new_text <- strsplit(content, "\n", fixed = TRUE)[[1]]
+
+  if (identical(new_text, original_text)) {
+    message("README.md is already up to date")
+    return(invisible(FALSE))
+  }
+
+  writeLines(new_text, readme_path)
+  message("Updated README.md with current pipeline data")
+  invisible(TRUE)
+}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Airports and Navaids on Supabase with API Access
 
 **Status:** Active
 **Version:** 1.2
-**Date:** 2026-01-31
+**Date:** <!-- pipeline:faa_date -->2026-01-31<!-- /pipeline:faa_date -->
 **Author:** Mike
 **Primary Data Source:** [FAA NASR 28-Day Subscription](https://www.faa.gov/air_traffic/flight_info/aeronav/aero_data/NASR_Subscription/)
 
@@ -24,7 +24,7 @@ curl "https://bjmjxipflycjnrwdujxp.supabase.co/rest/v1/airports?state_code=eq.CA
   -H "apikey: sb_publishable_B8oP0zIj3jUD8qX6lTeVOA_8lM_f1-E"
 ```
 
-This key is **read-only** - you can query all 5,308 airports and 1,650 navaids but cannot modify data. See [API Access](#api-access) for more examples.
+This key is **read-only** - you can query all <!-- pipeline:airports_count -->5,308<!-- /pipeline:airports_count --> airports and <!-- pipeline:navaids_count -->1,650<!-- /pipeline:navaids_count --> navaids but cannot modify data. See [API Access](#api-access) for more examples.
 
 ---
 
@@ -33,8 +33,8 @@ This key is **read-only** - you can query all 5,308 airports and 1,650 navaids b
 This project provides a reusable backend platform that ingests publicly available FAA aeronautical reference data (airports and navaids), stores it in a Supabase-hosted Postgres database, and exposes it via a REST API. The platform supports multiple downstream projects requiring authoritative lookup of identifiers and coordinates.
 
 **Current Data:**
-- 5,308 airports
-- 1,650 navaids
+- <!-- pipeline:airports_count -->5,308<!-- /pipeline:airports_count --> airports
+- <!-- pipeline:navaids_count -->1,650<!-- /pipeline:navaids_count --> navaids
 
 ---
 
@@ -92,7 +92,8 @@ airports_navaids/
 ├── R/
 │   ├── scrape_airports_navaids.R  # Main pipeline - orchestrates everything
 │   ├── clean_data.R               # Filters and cleans raw FAA CSV data
-│   └── push_to_supabase.R         # Pushes to Supabase via REST API
+│   ├── push_to_supabase.R         # Pushes to Supabase via REST API
+│   └── update_readme.R            # Updates README with pipeline results
 ├── sql/
 │   └── create_tables.sql          # PostgreSQL schema for Supabase
 ├── data/
@@ -159,6 +160,7 @@ The pipeline runs automatically via GitHub Actions.
 1. **Daily check** at 12:00 UTC - scrapes FAA website for current subscription date
 2. **Conditional execution** - full pipeline runs only when new data is available
 3. **Results** - written to GitHub Actions job summary (visible in workflow run page)
+4. **README auto-update** - commits updated counts and FAA date back to the repo
 
 ### Setup
 

--- a/tests/testthat/test-update_readme.R
+++ b/tests/testthat/test-update_readme.R
@@ -1,0 +1,184 @@
+# test-update_readme.R
+# Tests for R/update_readme.R
+
+source_project_file("update_readme.R")
+
+# --- Input validation tests ---
+
+test_that("update_readme validates faa_date argument", {
+  temp_dir <- withr::local_tempdir()
+  readme <- file.path(temp_dir, "README.md")
+  writeLines("test", readme)
+
+  expect_error(
+    update_readme("not-a-date", 5000, 1500, readme_path = readme)
+  )
+
+  expect_error(
+    update_readme(NULL, 5000, 1500, readme_path = readme)
+  )
+})
+
+test_that("update_readme validates count arguments", {
+  temp_dir <- withr::local_tempdir()
+  readme <- file.path(temp_dir, "README.md")
+  writeLines("test", readme)
+
+  expect_error(
+    update_readme(Sys.Date(), "abc", 1500, readme_path = readme)
+  )
+
+  expect_error(
+    update_readme(Sys.Date(), 5000, -1, readme_path = readme)
+  )
+})
+
+test_that("update_readme validates readme_path exists", {
+  expect_error(
+    update_readme(Sys.Date(), 5000, 1500,
+                  readme_path = "/nonexistent/README.md")
+  )
+})
+
+# --- Happy path tests ---
+
+test_that("update_readme replaces marker values", {
+  temp_dir <- withr::local_tempdir()
+  readme <- file.path(temp_dir, "README.md")
+
+  writeLines(c(
+    "# Test README",
+    "**Date:** <!-- pipeline:faa_date -->2025-01-01<!-- /pipeline:faa_date -->",
+    "- <!-- pipeline:airports_count -->1,000<!-- /pipeline:airports_count --> airports",
+    "- <!-- pipeline:navaids_count -->500<!-- /pipeline:navaids_count --> navaids"
+  ), readme)
+
+  result <- update_readme(
+    faa_date = as.Date("2026-02-28"),
+    airports_count = 5308,
+    navaids_count = 1650,
+    readme_path = readme
+  )
+
+  expect_true(result)
+
+  content <- readLines(readme)
+  expect_true(any(grepl("2026-02-28", content)))
+  expect_true(any(grepl("5,308", content)))
+  expect_true(any(grepl("1,650", content)))
+})
+
+test_that("update_readme replaces all occurrences of same marker", {
+  temp_dir <- withr::local_tempdir()
+  readme <- file.path(temp_dir, "README.md")
+
+  writeLines(c(
+    "First: <!-- pipeline:airports_count -->1,000<!-- /pipeline:airports_count -->",
+    "Second: <!-- pipeline:airports_count -->1,000<!-- /pipeline:airports_count -->"
+  ), readme)
+
+  update_readme(
+    faa_date = as.Date("2026-01-01"),
+    airports_count = 5308,
+    navaids_count = 1650,
+    readme_path = readme
+  )
+
+  content <- paste(readLines(readme), collapse = "\n")
+  matches <- gregexpr("5,308", content)[[1]]
+  expect_equal(length(matches), 2)
+})
+
+# --- Edge cases ---
+
+test_that("update_readme returns FALSE when content unchanged", {
+  temp_dir <- withr::local_tempdir()
+  readme <- file.path(temp_dir, "README.md")
+
+  writeLines(c(
+    "**Date:** <!-- pipeline:faa_date -->2026-01-31<!-- /pipeline:faa_date -->",
+    "<!-- pipeline:airports_count -->5,308<!-- /pipeline:airports_count --> airports",
+    "<!-- pipeline:navaids_count -->1,650<!-- /pipeline:navaids_count --> navaids"
+  ), readme)
+
+  result <- update_readme(
+    faa_date = as.Date("2026-01-31"),
+    airports_count = 5308,
+    navaids_count = 1650,
+    readme_path = readme
+  )
+
+  expect_false(result)
+})
+
+test_that("update_readme preserves non-marker content", {
+  temp_dir <- withr::local_tempdir()
+  readme <- file.path(temp_dir, "README.md")
+
+  writeLines(c(
+    "# My Project",
+    "Some description here.",
+    "**Date:** <!-- pipeline:faa_date -->2025-01-01<!-- /pipeline:faa_date -->",
+    "More content below.",
+    "## Section Two"
+  ), readme)
+
+  update_readme(
+    faa_date = as.Date("2026-02-28"),
+    airports_count = 5000,
+    navaids_count = 1500,
+    readme_path = readme
+  )
+
+  content <- readLines(readme)
+  expect_equal(content[1], "# My Project")
+  expect_equal(content[2], "Some description here.")
+  expect_equal(content[4], "More content below.")
+  expect_equal(content[5], "## Section Two")
+})
+
+test_that("update_readme handles zero counts", {
+  temp_dir <- withr::local_tempdir()
+  readme <- file.path(temp_dir, "README.md")
+
+  writeLines(c(
+    "<!-- pipeline:airports_count -->5,308<!-- /pipeline:airports_count --> airports"
+  ), readme)
+
+  result <- update_readme(
+    faa_date = as.Date("2026-01-01"),
+    airports_count = 0,
+    navaids_count = 0,
+    readme_path = readme
+  )
+
+  content <- readLines(readme)
+  expect_true(grepl("<!-- pipeline:airports_count -->0<!-- /pipeline:airports_count -->", content[1]))
+})
+
+# --- Error condition tests ---
+
+test_that("update_readme does not crash on README without markers", {
+  temp_dir <- withr::local_tempdir()
+  readme <- file.path(temp_dir, "README.md")
+
+  writeLines(c(
+    "# Plain README",
+    "No markers here.",
+    "5,308 airports mentioned in prose."
+  ), readme)
+
+  result <- update_readme(
+    faa_date = as.Date("2026-01-01"),
+    airports_count = 6000,
+    navaids_count = 1700,
+    readme_path = readme
+  )
+
+  # No markers found, so content is unchanged
+  expect_false(result)
+
+  # Original content preserved
+  content <- readLines(readme)
+  expect_equal(content[3], "5,308 airports mentioned in prose.")
+})


### PR DESCRIPTION
Add update_readme() function that replaces HTML marker-delimited values in README.md with current airport/navaid counts and FAA subscription date. Integrated into run_pipeline() and GitHub Actions workflow with an auto-commit step.

https://claude.ai/code/session_01GtZhahhVQ8fzx8Yca13aLM