### PR TITLE
chore(sql): add explicit Data API grants for airports/navaids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .gemini/
 .mcp.json
 .vscode/
+.worktrees/
 CLAUDE.md
 GEMINI.md
 supabase/

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ This project uses Supabase Row Level Security (RLS) with the new API key format:
 
 **Important:** The pipeline requires a `secret` key. Using a `publishable` key will fail on INSERT/DELETE operations.
 
+**Schema convention:** Tables in `sql/create_tables.sql` include explicit `GRANT` statements for the `anon`, `authenticated`, and `service_role` roles. These were auto-granted before Supabase's 2026-10-30 Data API policy change; specifying them explicitly keeps the schema portable to fresh projects and future tables. See [Supabase discussion #45329](https://github.com/orgs/supabase/discussions/45329).
+
 ---
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This project uses Supabase Row Level Security (RLS) with the new API key format:
 
 **Important:** The pipeline requires a `secret` key. Using a `publishable` key will fail on INSERT/DELETE operations.
 
-**Schema convention:** Tables in `sql/create_tables.sql` include explicit `GRANT` statements for the `anon`, `authenticated`, and `service_role` roles. These were auto-granted before Supabase's 2026-10-30 Data API policy change; specifying them explicitly keeps the schema portable to fresh projects and future tables. See [Supabase discussion #45329](https://github.com/orgs/supabase/discussions/45329).
+**Schema convention:** Tables in `sql/create_tables.sql` declare least-privilege Data API grants explicitly — `anon` and `authenticated` get `SELECT` only, `service_role` gets `SELECT, INSERT, UPDATE, DELETE` plus sequence access. The schema also `REVOKE`s Supabase's legacy auto-grants so the result is least-privilege regardless of when the schema is applied. Required because Supabase removes auto-grants for new `public`-schema tables on existing projects starting 2026-10-30. See [Supabase discussion #45329](https://github.com/orgs/supabase/discussions/45329).
 
 ---
 

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -76,3 +76,16 @@ CREATE POLICY "Allow public read access on navaids" ON navaids
 -- Write access: secret key (sb_secret_...) bypasses RLS entirely
 -- No INSERT/DELETE policies needed - pipeline uses secret key
 -- Public key (sb_publishable_...) is read-only via SELECT policy above
+
+-- Data API role grants
+-- Required for tables created in `public` after 2026-10-30 on existing
+-- projects. Before that date Supabase auto-grants these; specifying them
+-- explicitly makes this schema portable and durable.
+-- See: https://github.com/orgs/supabase/discussions/45329
+GRANT SELECT                         ON public.airports TO anon;
+GRANT SELECT                         ON public.airports TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.airports TO service_role;
+
+GRANT SELECT                         ON public.navaids  TO anon;
+GRANT SELECT                         ON public.navaids  TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.navaids  TO service_role;

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -77,15 +77,29 @@ CREATE POLICY "Allow public read access on navaids" ON navaids
 -- No INSERT/DELETE policies needed - pipeline uses secret key
 -- Public key (sb_publishable_...) is read-only via SELECT policy above
 
--- Data API role grants
+-- Data API: least-privilege grants
 -- Required for tables created in `public` after 2026-10-30 on existing
--- projects. Before that date Supabase auto-grants these; specifying them
--- explicitly makes this schema portable and durable.
+-- projects (Supabase removes auto-grants then). REVOKE statements ensure
+-- least-privilege regardless of when this schema is applied — before the
+-- cutoff Supabase auto-grants ALL privileges to anon/authenticated, so
+-- this strips that back to read-only via RLS + SELECT only.
 -- See: https://github.com/orgs/supabase/discussions/45329
-GRANT SELECT                         ON public.airports TO anon;
-GRANT SELECT                         ON public.airports TO authenticated;
-GRANT SELECT, INSERT, UPDATE, DELETE ON public.airports TO service_role;
 
-GRANT SELECT                         ON public.navaids  TO anon;
-GRANT SELECT                         ON public.navaids  TO authenticated;
+REVOKE ALL ON public.airports FROM anon, authenticated, service_role;
+REVOKE ALL ON public.navaids  FROM anon, authenticated, service_role;
+REVOKE ALL ON SEQUENCE public.airports_id_seq, public.navaids_id_seq
+  FROM anon, authenticated;
+
+-- anon: read-only (publishable key)
+GRANT SELECT ON public.airports TO anon;
+GRANT SELECT ON public.navaids  TO anon;
+
+-- authenticated: read-only (defensive; project has no auth flow today)
+GRANT SELECT ON public.airports TO authenticated;
+GRANT SELECT ON public.navaids  TO authenticated;
+
+-- service_role: full DML + sequence access (secret key / pipeline)
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.airports TO service_role;
 GRANT SELECT, INSERT, UPDATE, DELETE ON public.navaids  TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE public.airports_id_seq, public.navaids_id_seq
+  TO service_role;


### PR DESCRIPTION
## Summary

- Append explicit, least-privilege Data API grants to `sql/create_tables.sql` for `anon`, `authenticated`, and `service_role` on both `airports` and `navaids` (plus sequence grants for `service_role`).
- `REVOKE` Supabase's pre-cutoff legacy auto-grants so the schema is least-privilege regardless of when it is applied.
- Update `README.md` with a short schema-convention note.
- Closes #9.

## Context

Supabase emailed on 2026-05-13 announcing a Data API default change. Starting **2026-10-30**, new tables in `public` on existing projects will not be auto-granted to the Data API roles.

**Baseline finding (in-flight scope expansion):** A pre-migration check of `information_schema.role_table_grants` showed the live tables grant all 7 privileges (SELECT, INSERT, UPDATE, DELETE, REFERENCES, TRIGGER, TRUNCATE) to `anon`, `authenticated`, and `service_role`. `anon` is over-privileged at the SQL layer; read-only behavior is enforced only by RLS. This PR fixes that by tightening to least-privilege.

Reference: https://github.com/orgs/supabase/discussions/45329

## Final grant model

| Role | Table privileges | Sequence privileges |
|---|---|---|
| `anon` | `SELECT` | none |
| `authenticated` | `SELECT` | none |
| `service_role` | `SELECT, INSERT, UPDATE, DELETE` | `USAGE, SELECT` |

## Test plan

- [x] Baseline live grants on `airports` and `navaids` — confirmed over-privileged.
- [ ] Apply migration `tighten_data_api_grants_airports_navaids` to prod (REVOKE + GRANT).
- [ ] Re-query `role_table_grants`; confirm only the privileges in the table above remain.
- [ ] `GET /rest/v1/airports?limit=1` with publishable key returns 200.
- [ ] Run pipeline `clear_table()` + `push_to_supabase()` smoke check via secret key (insert/delete still work via service_role).
- [ ] Supabase Security Advisor shows no Data API exposure warnings on these tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)