### PR TITLE
feat(readme): add visual identity, hex sticker, and live badges

### DIFF
--- a/.github/assets/README.md
+++ b/.github/assets/README.md
@@ -1,0 +1,71 @@
+# Repo identity assets
+
+Visual identity for `airports-navaids`. Three SVG sources, one regeneration
+script, and one upload step.
+
+## Files
+
+| File | Purpose | Where it's used |
+|---|---|---|
+| `readme-header.svg` | 1000 x 300 dark banner | Top of `README.md` via `<img src>` |
+| `social-preview.svg` | 1280 x 640 dark banner | Source for the Social Preview PNG |
+| `social-preview.png` | Rasterized 1280 x 640 | Uploaded once via GitHub Settings |
+| `hex-sticker.svg` | 200 x 231 hex sticker | Hand-authored hex used inline |
+| `hex-sticker.png` | Rasterized hex | Laptop stickers, slides, social posts |
+
+## Regenerating the Social Preview PNG
+
+GitHub's Settings page accepts PNG/JPG/GIF only. Rasterize the SVG source:
+
+```bash
+brew install librsvg  # one-time
+rsvg-convert -w 1280 -h 640 .github/assets/social-preview.svg \
+  -o .github/assets/social-preview.png
+```
+
+Then upload via **Settings -> General -> Social preview -> Upload an image**.
+The upload is a one-time manual step (the `gh` CLI does not cover it).
+
+## Regenerating the README header PNG (optional)
+
+GitHub renders SVG directly in markdown via `<img src>`, so the SVG source
+is what `README.md` references. If you ever need a raster fallback (some
+RSS readers or third-party clients strip SVG):
+
+```bash
+rsvg-convert -w 1000 -h 300 .github/assets/readme-header.svg \
+  -o .github/assets/readme-header.png
+```
+
+## Regenerating the hex sticker (R hexSticker package)
+
+The hand-authored `hex-sticker.svg` is the canonical version. To produce a
+PNG via the R community's `hexSticker` package:
+
+```bash
+Rscript -e 'install.packages("hexSticker")'   # one-time, not snapshotted
+Rscript -e 'Sys.setenv(REGENERATE_HEX="1"); source("R/generate_hex.R")'
+```
+
+`R/generate_hex.R` is gated so it only runs when `REGENERATE_HEX=1` or the
+session is interactive. It never runs in CI and `hexSticker` never lands
+in `renv.lock`.
+
+## Design system reference
+
+Palette and motifs locked during 2026-05-25 brainstorming:
+
+| Token | Value | Use |
+|---|---|---|
+| Background | `#0d1117` | Banner background (GitHub native dark) |
+| Foreground | `#f0f6fc` | Primary text |
+| Muted | `#8b949e` | Tagline, secondary text |
+| Accent | `#3fb950` | Accent bar, hex border, GET arrow |
+| Code panel | `#161b22` | Code block background |
+| Code border | `#21262d` | Code block stroke |
+| Hex body | linear-gradient `#1f4e79` -> `#2d5f8d` | Hex sticker fill |
+
+Typography: system sans (`-apple-system, BlinkMacSystemFont, "Segoe UI", ...`)
+for headings and tagline; system mono (`ui-monospace, "SF Mono", Menlo, ...`)
+for the code snippet. SVG inherits the viewer's installed fonts, so renders
+crisply on every platform.

--- a/.github/assets/hex-sticker.svg
+++ b/.github/assets/hex-sticker.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 231" width="200" height="231" role="img" aria-label="airports-navaids hex sticker">
+  <defs>
+    <linearGradient id="hexFill" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f4e79"/>
+      <stop offset="100%" stop-color="#2d5f8d"/>
+    </linearGradient>
+    <style>
+      .sans { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    </style>
+  </defs>
+
+  <!-- Pointy-top hex inset by 3px for stroke -->
+  <polygon points="100,3 197,57.75 197,173.25 100,228 3,173.25 3,57.75"
+           fill="url(#hexFill)" stroke="#3fb950" stroke-width="3"
+           filter="drop-shadow(0 4px 12px rgba(0,0,0,0.35))"/>
+
+  <!-- Airplane glyph -->
+  <g transform="translate(100, 92) scale(1.5)" fill="#ffffff">
+    <path d="M -22 6 L -8 4 L -4 -14 L 0 -22 L 4 -14 L 8 4 L 22 6 L 22 12 L 6 10 L 4 22 L 10 26 L 10 30 L 0 28 L -10 30 L -10 26 L -4 22 L -6 10 L -22 12 Z"/>
+  </g>
+
+  <text class="sans" x="100" y="162" text-anchor="middle" font-size="19" font-weight="700" fill="#ffffff">airports</text>
+  <text class="sans" x="100" y="184" text-anchor="middle" font-size="19" font-weight="700" fill="#ffffff">navaids</text>
+  <text class="sans" x="100" y="210" text-anchor="middle" font-size="11" font-weight="500" fill="#a8c8e8" letter-spacing="1.8">FAA · NASR</text>
+</svg>

--- a/.github/assets/hex-sticker.svg
+++ b/.github/assets/hex-sticker.svg
@@ -15,12 +15,12 @@
            fill="url(#hexFill)" stroke="#3fb950" stroke-width="3"
            filter="drop-shadow(0 4px 12px rgba(0,0,0,0.35))"/>
 
-  <!-- Airplane glyph -->
-  <g transform="translate(100, 92) scale(1.5)" fill="#ffffff">
-    <path d="M -22 6 L -8 4 L -4 -14 L 0 -22 L 4 -14 L 8 4 L 22 6 L 22 12 L 6 10 L 4 22 L 10 26 L 10 30 L 0 28 L -10 30 L -10 26 L -4 22 L -6 10 L -22 12 Z"/>
+  <!-- Airliner glyph (Material "flight" icon, top-down view, nose up) -->
+  <g transform="translate(100, 78) scale(2.4) translate(-11.5, -11.5)" fill="#ffffff">
+    <path d="M21,16v-2l-8-5V3.5C13,2.67,12.33,2,11.5,2S10,2.67,10,3.5V9l-8,5v2l8-2.5V19l-2,1.5V21l3.5-1l3.5,1v-1.5L13,19v-5.5L21,16z"/>
   </g>
 
-  <text class="sans" x="100" y="162" text-anchor="middle" font-size="19" font-weight="700" fill="#ffffff">airports</text>
-  <text class="sans" x="100" y="184" text-anchor="middle" font-size="19" font-weight="700" fill="#ffffff">navaids</text>
-  <text class="sans" x="100" y="210" text-anchor="middle" font-size="11" font-weight="500" fill="#a8c8e8" letter-spacing="1.8">FAA · NASR</text>
+  <text class="sans" x="100" y="138" text-anchor="middle" font-size="19" font-weight="700" fill="#ffffff">airports</text>
+  <text class="sans" x="100" y="160" text-anchor="middle" font-size="19" font-weight="700" fill="#ffffff">navaids</text>
+  <text class="sans" x="100" y="182" text-anchor="middle" font-size="11" font-weight="500" fill="#a8c8e8" letter-spacing="1.8">FAA · NASR</text>
 </svg>

--- a/.github/assets/readme-header.svg
+++ b/.github/assets/readme-header.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 300" width="1000" height="300" role="img" aria-label="airports-navaids: FAA aeronautical reference data on Supabase">
+  <defs>
+    <radialGradient id="rightGlow" cx="80%" cy="50%" r="55%">
+      <stop offset="0%" stop-color="#3fb950" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#3fb950" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="hexFill" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f4e79"/>
+      <stop offset="100%" stop-color="#2d5f8d"/>
+    </linearGradient>
+    <style>
+      .sans { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+      .mono { font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1000" height="300" rx="10" fill="#0d1117"/>
+  <rect width="1000" height="300" rx="10" fill="url(#rightGlow)"/>
+
+  <!-- Eyebrow label -->
+  <text class="sans" x="48" y="56" font-size="11" font-weight="600" fill="#6e7681" letter-spacing="2.2">OPEN DATA · 28-DAY REFRESH</text>
+
+  <!-- Green accent bar -->
+  <rect x="48" y="70" width="42" height="4" rx="1" fill="#3fb950"/>
+
+  <!-- Title -->
+  <text class="sans" x="48" y="118" font-size="40" font-weight="700" fill="#f0f6fc" letter-spacing="-0.8">airports-navaids</text>
+
+  <!-- Tagline -->
+  <text class="sans" x="48" y="148" font-size="16" fill="#8b949e">FAA aeronautical reference data on Supabase, fresh every 28 days.</text>
+
+  <!-- Code block -->
+  <g transform="translate(48, 188)">
+    <rect width="560" height="74" rx="6" fill="#161b22" stroke="#21262d" stroke-width="1"/>
+    <rect x="0" y="0" width="2" height="74" fill="#3fb950"/>
+    <text class="mono" x="16" y="28" font-size="13">
+      <tspan fill="#ff7b72">GET</tspan><tspan fill="#7d8590"> /rest/v1/airports?arpt_id=eq.</tspan><tspan fill="#79c0ff">LAX</tspan>
+    </text>
+    <text class="mono" x="16" y="54" font-size="13">
+      <tspan fill="#3fb950">→</tspan><tspan fill="#7d8590"> { lat: </tspan><tspan fill="#a5d6ff">33.94</tspan><tspan fill="#7d8590">, long: </tspan><tspan fill="#a5d6ff">-118.41</tspan><tspan fill="#7d8590">, elev: </tspan><tspan fill="#a5d6ff">125</tspan><tspan fill="#7d8590"> }</tspan>
+    </text>
+  </g>
+
+  <!-- Hex sticker (right side) -->
+  <g transform="translate(820, 75)">
+    <!-- Hex shape: 130w x 150h, pointy-top orientation -->
+    <!-- Vertices for a 130x150 hex with pointy top -->
+    <polygon points="65,0 130,37.5 130,112.5 65,150 0,112.5 0,37.5"
+             fill="url(#hexFill)" stroke="#3fb950" stroke-width="2"
+             filter="drop-shadow(0 6px 18px rgba(0,0,0,0.45))"/>
+    <!-- Plane glyph centered above text -->
+    <g transform="translate(65, 58)" fill="#ffffff">
+      <!-- Simplified airplane silhouette pointing up-right -->
+      <path d="M -22 6 L -8 4 L -4 -14 L 0 -22 L 4 -14 L 8 4 L 22 6 L 22 12 L 6 10 L 4 22 L 10 26 L 10 30 L 0 28 L -10 30 L -10 26 L -4 22 L -6 10 L -22 12 Z"/>
+    </g>
+    <text class="sans" x="65" y="105" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">airports</text>
+    <text class="sans" x="65" y="120" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">navaids</text>
+    <text class="sans" x="65" y="138" text-anchor="middle" font-size="9" font-weight="500" fill="#a8c8e8" letter-spacing="1.2">FAA · NASR</text>
+  </g>
+</svg>

--- a/.github/assets/readme-header.svg
+++ b/.github/assets/readme-header.svg
@@ -50,13 +50,12 @@
     <polygon points="65,0 130,37.5 130,112.5 65,150 0,112.5 0,37.5"
              fill="url(#hexFill)" stroke="#3fb950" stroke-width="2"
              filter="drop-shadow(0 6px 18px rgba(0,0,0,0.45))"/>
-    <!-- Plane glyph centered above text -->
-    <g transform="translate(65, 58)" fill="#ffffff">
-      <!-- Simplified airplane silhouette pointing up-right -->
-      <path d="M -22 6 L -8 4 L -4 -14 L 0 -22 L 4 -14 L 8 4 L 22 6 L 22 12 L 6 10 L 4 22 L 10 26 L 10 30 L 0 28 L -10 30 L -10 26 L -4 22 L -6 10 L -22 12 Z"/>
+    <!-- Airliner glyph (Material "flight" icon, top-down view, nose up) -->
+    <g transform="translate(65, 48) scale(1.55) translate(-11.5, -11.5)" fill="#ffffff">
+      <path d="M21,16v-2l-8-5V3.5C13,2.67,12.33,2,11.5,2S10,2.67,10,3.5V9l-8,5v2l8-2.5V19l-2,1.5V21l3.5-1l3.5,1v-1.5L13,19v-5.5L21,16z"/>
     </g>
-    <text class="sans" x="65" y="105" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">airports</text>
-    <text class="sans" x="65" y="120" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">navaids</text>
-    <text class="sans" x="65" y="138" text-anchor="middle" font-size="9" font-weight="500" fill="#a8c8e8" letter-spacing="1.2">FAA · NASR</text>
+    <text class="sans" x="65" y="92" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">airports</text>
+    <text class="sans" x="65" y="107" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">navaids</text>
+    <text class="sans" x="65" y="125" text-anchor="middle" font-size="9" font-weight="500" fill="#a8c8e8" letter-spacing="1.2">FAA · NASR</text>
   </g>
 </svg>

--- a/.github/assets/social-preview.svg
+++ b/.github/assets/social-preview.svg
@@ -57,12 +57,12 @@
     <polygon points="120,0 240,69.3 240,207.8 120,277 0,207.8 0,69.3"
              fill="url(#hexFill)" stroke="#3fb950" stroke-width="3"
              filter="drop-shadow(0 12px 32px rgba(0,0,0,0.55))"/>
-    <!-- Airplane glyph -->
-    <g transform="translate(120, 108) scale(1.85)" fill="#ffffff">
-      <path d="M -22 6 L -8 4 L -4 -14 L 0 -22 L 4 -14 L 8 4 L 22 6 L 22 12 L 6 10 L 4 22 L 10 26 L 10 30 L 0 28 L -10 30 L -10 26 L -4 22 L -6 10 L -22 12 Z"/>
+    <!-- Airliner glyph (Material "flight" icon, top-down view, nose up) -->
+    <g transform="translate(120, 92) scale(3.0) translate(-11.5, -11.5)" fill="#ffffff">
+      <path d="M21,16v-2l-8-5V3.5C13,2.67,12.33,2,11.5,2S10,2.67,10,3.5V9l-8,5v2l8-2.5V19l-2,1.5V21l3.5-1l3.5,1v-1.5L13,19v-5.5L21,16z"/>
     </g>
-    <text class="sans" x="120" y="192" text-anchor="middle" font-size="24" font-weight="700" fill="#ffffff">airports</text>
-    <text class="sans" x="120" y="220" text-anchor="middle" font-size="24" font-weight="700" fill="#ffffff">navaids</text>
-    <text class="sans" x="120" y="252" text-anchor="middle" font-size="14" font-weight="500" fill="#a8c8e8" letter-spacing="2.2">FAA · NASR</text>
+    <text class="sans" x="120" y="170" text-anchor="middle" font-size="24" font-weight="700" fill="#ffffff">airports</text>
+    <text class="sans" x="120" y="198" text-anchor="middle" font-size="24" font-weight="700" fill="#ffffff">navaids</text>
+    <text class="sans" x="120" y="228" text-anchor="middle" font-size="14" font-weight="500" fill="#a8c8e8" letter-spacing="2.2">FAA · NASR</text>
   </g>
 </svg>

--- a/.github/assets/social-preview.svg
+++ b/.github/assets/social-preview.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 640" width="1280" height="640" role="img" aria-label="airports-navaids: FAA aeronautical reference data on Supabase">
+  <defs>
+    <radialGradient id="rightGlow" cx="78%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#3fb950" stop-opacity="0.14"/>
+      <stop offset="100%" stop-color="#3fb950" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="hexFill" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f4e79"/>
+      <stop offset="100%" stop-color="#2d5f8d"/>
+    </linearGradient>
+    <pattern id="gridDots" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+      <circle cx="1" cy="1" r="1" fill="#21262d"/>
+    </pattern>
+    <style>
+      .sans { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+      .mono { font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1280" height="640" fill="#0d1117"/>
+  <rect width="1280" height="640" fill="url(#gridDots)" opacity="0.6"/>
+  <rect width="1280" height="640" fill="url(#rightGlow)"/>
+
+  <!-- Eyebrow -->
+  <text class="sans" x="96" y="140" font-size="16" font-weight="600" fill="#6e7681" letter-spacing="3">OPEN DATA · 28-DAY REFRESH</text>
+
+  <!-- Green accent bar -->
+  <rect x="96" y="160" width="64" height="6" rx="1.5" fill="#3fb950"/>
+
+  <!-- Title -->
+  <text class="sans" x="96" y="248" font-size="72" font-weight="700" fill="#f0f6fc" letter-spacing="-1.5">airports-navaids</text>
+
+  <!-- Tagline (two lines for breathing room at this aspect ratio) -->
+  <text class="sans" x="96" y="296" font-size="26" fill="#8b949e">FAA aeronautical reference data on Supabase,</text>
+  <text class="sans" x="96" y="332" font-size="26" fill="#8b949e">fresh every 28 days.</text>
+
+  <!-- Code block -->
+  <g transform="translate(96, 388)">
+    <rect width="720" height="120" rx="8" fill="#161b22" stroke="#21262d" stroke-width="1"/>
+    <rect x="0" y="0" width="3" height="120" fill="#3fb950"/>
+    <text class="mono" x="24" y="46" font-size="18">
+      <tspan fill="#ff7b72">GET</tspan><tspan fill="#7d8590"> /rest/v1/airports?arpt_id=eq.</tspan><tspan fill="#79c0ff">LAX</tspan>
+    </text>
+    <text class="mono" x="24" y="86" font-size="18">
+      <tspan fill="#3fb950">→</tspan><tspan fill="#7d8590"> { lat: </tspan><tspan fill="#a5d6ff">33.94</tspan><tspan fill="#7d8590">, long: </tspan><tspan fill="#a5d6ff">-118.41</tspan><tspan fill="#7d8590">, elev: </tspan><tspan fill="#a5d6ff">125</tspan><tspan fill="#7d8590"> }</tspan>
+    </text>
+  </g>
+
+  <!-- Footer hint -->
+  <text class="sans" x="96" y="558" font-size="16" fill="#6e7681">github.com/mikehickey2/airports-navaids</text>
+
+  <!-- Hex sticker (right side, larger) -->
+  <g transform="translate(960, 200)">
+    <!-- 240w x 277h pointy-top hex -->
+    <polygon points="120,0 240,69.3 240,207.8 120,277 0,207.8 0,69.3"
+             fill="url(#hexFill)" stroke="#3fb950" stroke-width="3"
+             filter="drop-shadow(0 12px 32px rgba(0,0,0,0.55))"/>
+    <!-- Airplane glyph -->
+    <g transform="translate(120, 108) scale(1.85)" fill="#ffffff">
+      <path d="M -22 6 L -8 4 L -4 -14 L 0 -22 L 4 -14 L 8 4 L 22 6 L 22 12 L 6 10 L 4 22 L 10 26 L 10 30 L 0 28 L -10 30 L -10 26 L -4 22 L -6 10 L -22 12 Z"/>
+    </g>
+    <text class="sans" x="120" y="192" text-anchor="middle" font-size="24" font-weight="700" fill="#ffffff">airports</text>
+    <text class="sans" x="120" y="220" text-anchor="middle" font-size="24" font-weight="700" fill="#ffffff">navaids</text>
+    <text class="sans" x="120" y="252" text-anchor="middle" font-size="14" font-weight="500" fill="#a8c8e8" letter-spacing="2.2">FAA · NASR</text>
+  </g>
+</svg>

--- a/.github/badges/airports.json
+++ b/.github/badges/airports.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "airports",
+  "message": "5,305",
+  "color": "blue"
+}

--- a/.github/badges/cycle.json
+++ b/.github/badges/cycle.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "NASR cycle",
+  "message": "2026-05-14",
+  "color": "brightgreen"
+}

--- a/.github/badges/navaids.json
+++ b/.github/badges/navaids.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "navaids",
+  "message": "1,634",
+  "color": "blue"
+}

--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -132,7 +132,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md data/pipeline_history.csv
+          git add README.md data/pipeline_history.csv .github/badges/
           if git diff --cached --quiet; then
             echo "No changes to commit - skipping"
           else

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .mcp.json
 .vscode/
 .worktrees/
+.superpowers/
 CLAUDE.md
 GEMINI.md
 supabase/

--- a/R/generate_hex.R
+++ b/R/generate_hex.R
@@ -1,0 +1,64 @@
+# generate_hex.R
+# Dev-only generator for the airports-navaids hex sticker PNG.
+#
+# This script is intentionally NOT part of the runtime pipeline. It is gated
+# so it never runs in CI and the hexSticker package never lands in the
+# runtime path. To regenerate the hex sticker:
+#
+#   Rscript -e 'Sys.setenv(REGENERATE_HEX = "1"); source("R/generate_hex.R")'
+#
+# Or in an interactive session:
+#
+#   source("R/generate_hex.R")
+#
+# Requirements (install ad hoc, do not snapshot into renv.lock):
+#
+#   install.packages("hexSticker")
+#
+# A hand-authored SVG version of the same hex lives at
+# .github/assets/hex-sticker.svg and is what the README references. Running
+# this script overwrites .github/assets/hex-sticker.png with a PNG generated
+# by the hexSticker package, which is the format expected by environments
+# that need rasterized output (laptop stickers, slide decks, social posts).
+
+is_regen_run <- interactive() || nzchar(Sys.getenv("REGENERATE_HEX"))
+
+if (!is_regen_run) {
+  message(
+    "generate_hex.R sourced non-interactively without REGENERATE_HEX=1; ",
+    "skipping. This is expected during normal pipeline runs."
+  )
+} else {
+  if (!requireNamespace("hexSticker", quietly = TRUE)) {
+    stop(
+      "hexSticker is not installed. Install it with ",
+      "install.packages(\"hexSticker\") before regenerating."
+    )
+  }
+
+  output_path <- ".github/assets/hex-sticker.png"
+
+  hexSticker::sticker(
+    subplane <- function() {
+      grid::grid.text("✈", gp = grid::gpar(fontsize = 96, col = "white"))
+    },
+    package = "airports\nnavaids",
+    p_size = 18,
+    p_y = 1.45,
+    p_color = "#ffffff",
+    s_x = 1.0,
+    s_y = 0.85,
+    s_width = 1.2,
+    s_height = 1.0,
+    h_fill = "#1f4e79",
+    h_color = "#3fb950",
+    h_size = 1.8,
+    url = "FAA · NASR",
+    u_color = "#a8c8e8",
+    u_size = 5,
+    filename = output_path,
+    dpi = 600
+  )
+
+  message("Wrote ", output_path)
+}

--- a/R/scrape_airports_navaids.R
+++ b/R/scrape_airports_navaids.R
@@ -302,6 +302,9 @@ run_pipeline <- function(force = FALSE) {
   # Update README with current data
   update_readme(current_date, result$airports_count, result$navaids_count)
 
+  # Update shields.io endpoint badge JSON
+  update_badges(current_date, result$airports_count, result$navaids_count)
+
   message("Done! Data updated to ", format(current_date, "%d %b %Y"))
   result
 }

--- a/R/update_readme.R
+++ b/R/update_readme.R
@@ -1,8 +1,10 @@
 # update_readme.R
 # Updates README.md with current pipeline data (counts and FAA date)
+# and writes shields.io endpoint JSON files for the README badge row.
 
 library(checkmate)
 library(rlang)
+library(jsonlite)
 
 # Expected marker keys that should be present in README.md
 expected_markers <- c("faa_date", "airports_count", "navaids_count")
@@ -91,4 +93,65 @@ warn_missing_markers <- function(content) {
   }
 
   invisible(NULL)
+}
+
+#' Write shields.io endpoint JSON badge files
+#'
+#' Generates three JSON files conforming to the shields.io endpoint schema
+#' so the README badge row reflects the current NASR cycle without
+#' regenerating any image. Shields.io fetches these JSON files on every
+#' README view via the raw GitHub URL.
+#'
+#' Schema: https://shields.io/badges/endpoint-badge
+#'
+#' @param faa_date Date object: FAA subscription effective date
+#' @param airports_count Integer: number of airports
+#' @param navaids_count Integer: number of navaids
+#' @param badges_dir Character: directory to write badge JSON files
+#'   (default: ".github/badges")
+#' @return Invisibly returns a character vector of paths written
+#' @export
+update_badges <- function(faa_date,
+                          airports_count,
+                          navaids_count,
+                          badges_dir = ".github/badges") {
+  checkmate::assert_date(faa_date, len = 1, any.missing = FALSE)
+  checkmate::assert_integerish(airports_count, lower = 0, len = 1)
+  checkmate::assert_integerish(navaids_count, lower = 0, len = 1)
+  checkmate::assert_string(badges_dir, min.chars = 1)
+
+  if (!dir.exists(badges_dir)) {
+    dir.create(badges_dir, recursive = TRUE)
+  }
+
+  badges <- list(
+    cycle = list(
+      schemaVersion = 1L,
+      label = "NASR cycle",
+      message = format(faa_date, "%Y-%m-%d"),
+      color = "brightgreen"
+    ),
+    airports = list(
+      schemaVersion = 1L,
+      label = "airports",
+      message = trimws(format(airports_count, big.mark = ",")),
+      color = "blue"
+    ),
+    navaids = list(
+      schemaVersion = 1L,
+      label = "navaids",
+      message = trimws(format(navaids_count, big.mark = ",")),
+      color = "blue"
+    )
+  )
+
+  written <- vapply(names(badges), function(key) {
+    path <- file.path(badges_dir, paste0(key, ".json"))
+    jsonlite::write_json(badges[[key]], path,
+                         auto_unbox = TRUE, pretty = TRUE)
+    path
+  }, character(1))
+
+  message("Wrote ", length(written), " badge JSON files to ", badges_dir)
+  invisible(unname(written))
 }

--- a/README.md
+++ b/README.md
@@ -1,13 +1,22 @@
+<div align="center">
+  <img src="./.github/assets/readme-header.svg"
+       alt="airports-navaids: FAA aeronautical reference data on Supabase"
+       width="1000">
+
+  <p>
+    <a href="https://github.com/mikehickey2/airports-navaids/actions/workflows/daily-pipeline.yml"><img src="https://github.com/mikehickey2/airports-navaids/actions/workflows/daily-pipeline.yml/badge.svg" alt="CI"></a>
+    <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmikehickey2%2Fairports-navaids%2Fmain%2F.github%2Fbadges%2Fcycle.json" alt="NASR cycle">
+    <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmikehickey2%2Fairports-navaids%2Fmain%2F.github%2Fbadges%2Fairports.json" alt="airports">
+    <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmikehickey2%2Fairports-navaids%2Fmain%2F.github%2Fbadges%2Fnavaids.json" alt="navaids">
+    <img src="https://img.shields.io/badge/license-MIT-green" alt="license">
+    <img src="https://img.shields.io/badge/R-4.5-blue" alt="R 4.5">
+  </p>
+</div>
+
 # FAA Aeronautical Reference Platform
 
-Airports and Navaids on Supabase with API Access
-
-**Status:** Active  
-**Version:** 1.2.1  
-**Software Date:** 2026-02-18  
-**NASR Database Date:** <!-- pipeline:faa_date -->2026-05-14<!-- /pipeline:faa_date -->  
-**Author:** Mike Hickey  
-**Primary Data Source:** [FAA NASR 28-Day Subscription](https://www.faa.gov/air_traffic/flight_info/aeronav/aero_data/NASR_Subscription/)  
+**Status:** Active &nbsp;·&nbsp; **Version:** 1.2.1 &nbsp;·&nbsp; **Software Date:** 2026-02-18 &nbsp;·&nbsp; **NASR Database Date:** <!-- pipeline:faa_date -->2026-05-14<!-- /pipeline:faa_date --> &nbsp;·&nbsp; **Author:** Mike Hickey  
+**Primary Data Source:** [FAA NASR 28-Day Subscription](https://www.faa.gov/air_traffic/flight_info/aeronav/aero_data/NASR_Subscription/)
 
 ---
 

--- a/tests/testthat/test-update_readme.R
+++ b/tests/testthat/test-update_readme.R
@@ -214,3 +214,104 @@ test_that("update_readme warns when some markers are missing", {
     class = "update_readme_missing_markers"
   )
 })
+
+# --- update_badges() tests ---
+
+test_that("update_badges validates faa_date argument", {
+  temp_dir <- withr::local_tempdir()
+
+  expect_error(
+    update_badges("not-a-date", 5000, 1500, badges_dir = temp_dir)
+  )
+
+  expect_error(
+    update_badges(NA, 5000, 1500, badges_dir = temp_dir)
+  )
+})
+
+test_that("update_badges validates count arguments", {
+  temp_dir <- withr::local_tempdir()
+
+  expect_error(
+    update_badges(Sys.Date(), "abc", 1500, badges_dir = temp_dir)
+  )
+
+  expect_error(
+    update_badges(Sys.Date(), 5000, -1, badges_dir = temp_dir)
+  )
+})
+
+test_that("update_badges writes three valid shields.io endpoint JSON files", {
+  temp_dir <- withr::local_tempdir()
+  badges_dir <- file.path(temp_dir, "badges")
+
+  written <- update_badges(
+    faa_date = as.Date("2026-05-14"),
+    airports_count = 5305,
+    navaids_count = 1634,
+    badges_dir = badges_dir
+  )
+
+  expect_length(written, 3)
+  expect_true(all(file.exists(written)))
+  expect_setequal(
+    basename(written),
+    c("cycle.json", "airports.json", "navaids.json")
+  )
+
+  cycle <- jsonlite::read_json(file.path(badges_dir, "cycle.json"))
+  expect_equal(cycle$schemaVersion, 1)
+  expect_equal(cycle$label, "NASR cycle")
+  expect_equal(cycle$message, "2026-05-14")
+  expect_equal(cycle$color, "brightgreen")
+
+  airports <- jsonlite::read_json(file.path(badges_dir, "airports.json"))
+  expect_equal(airports$message, "5,305")
+  expect_equal(airports$color, "blue")
+
+  navaids <- jsonlite::read_json(file.path(badges_dir, "navaids.json"))
+  expect_equal(navaids$message, "1,634")
+})
+
+test_that("update_badges creates badges_dir if missing", {
+  temp_dir <- withr::local_tempdir()
+  badges_dir <- file.path(temp_dir, "nested", "badges")
+  expect_false(dir.exists(badges_dir))
+
+  update_badges(
+    faa_date = as.Date("2026-05-14"),
+    airports_count = 5305,
+    navaids_count = 1634,
+    badges_dir = badges_dir
+  )
+
+  expect_true(dir.exists(badges_dir))
+  expect_true(file.exists(file.path(badges_dir, "cycle.json")))
+})
+
+test_that("update_badges handles zero counts", {
+  temp_dir <- withr::local_tempdir()
+
+  update_badges(
+    faa_date = as.Date("2026-05-14"),
+    airports_count = 0,
+    navaids_count = 0,
+    badges_dir = temp_dir
+  )
+
+  airports <- jsonlite::read_json(file.path(temp_dir, "airports.json"))
+  expect_equal(airports$message, "0")
+})
+
+test_that("update_badges overwrites existing files (idempotency)", {
+  temp_dir <- withr::local_tempdir()
+
+  update_badges(as.Date("2026-04-16"), 5305, 1638, badges_dir = temp_dir)
+  update_badges(as.Date("2026-05-14"), 5305, 1634, badges_dir = temp_dir)
+
+  cycle <- jsonlite::read_json(file.path(temp_dir, "cycle.json"))
+  expect_equal(cycle$message, "2026-05-14")
+
+  navaids <- jsonlite::read_json(file.path(temp_dir, "navaids.json"))
+  expect_equal(navaids$message, "1,634")
+})


### PR DESCRIPTION
## Summary

Coherent visual identity across three surfaces, plus a live-badge mechanism that piggybacks on the existing FAA pipeline.

- **README header**: centered SVG banner (1000x300) at \`.github/assets/readme-header.svg\` plus a 6-badge row. The three "dynamic" badges (NASR cycle, airports, navaids) are shields.io endpoint badges that read JSON from \`.github/badges/\`, which CI now updates each cycle.
- **Social Preview**: \`.github/assets/social-preview.svg\` (1280x640) ready to be rasterized and uploaded once via Settings > General > Social preview (rsvg-convert one-liner documented in \`.github/assets/README.md\`).
- **Hex sticker**: hand-authored \`hex-sticker.svg\` is canonical. \`R/generate_hex.R\` is a dev-only gated script using the \`hexSticker\` package for PNG output; never runs in CI and \`hexSticker\` stays out of \`renv.lock\`.
- **Live badges**: new \`update_badges()\` in \`R/update_readme.R\` writes shields.io endpoint JSON each cycle. Wired into \`run_pipeline()\` after \`update_readme()\`. CI git-add line extended to include \`.github/badges/\`.
- **No runtime deps added.** \`jsonlite\` was already in \`renv.lock\`. Important given the R 4.6 / backports blocker.

## Test plan

- [ ] CI runs lintr + testthat (7 new test cases for \`update_badges()\` covering validation, happy path, idempotency, zero counts, dir creation).
- [ ] Banner renders in the GitHub PR README preview (SVG via raw URL).
- [ ] All 6 badges render in the README preview. The three dynamic ones should already show current values (cycle=2026-05-14, airports=5,305, navaids=1,634) because shields.io fetches the seeded JSON from this branch.
- [ ] After merge: trigger the daily pipeline once with force=true; confirm the post-run commit includes refreshed \`.github/badges/*.json\` and that badges update accordingly.
- [ ] After merge: \`gh repo edit\` to populate the About panel (description + 6 topics + homepage URL).
- [ ] After merge: convert \`social-preview.svg\` to PNG and upload via Settings > General > Social preview.

## Design decisions captured during brainstorming

Locked in 2026-05-25 Visual Companion session:

- Direction: "API infrastructure" aesthetic (dark slate, monospace accent, GitHub-native palette).
- R community signal: include a hex sticker.
- Live numbers go to badges, not into the banner art (banner stays static; reduces maintenance).
- About description (final, no em-dashes):
  > FAA aeronautical reference data on Supabase: 5,300+ airports and 1,600+ navaids from the NASR 28-day subscription, cleaned and exposed as a public REST API. Use the published read-only key (no signup), or fork the repo and stand up your own instance.

Plan file: \`/Users/mikehickey2/.claude/plans/bubbly-spinning-iverson.md\` (local).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>