### PR TITLE
feat: add private-use airports and facility-use column

### DIFF
--- a/R/clean_data.R
+++ b/R/clean_data.R
@@ -14,19 +14,31 @@ library(rlang)
 
 # --- Schema Definitions ---
 #
-# Airports validation rules:
-#   - ARPT_ID: 1-3 chars (4-char military IDs filtered out)
-#   - Row count: warn if < 5000
-#   - LAT_DECIMAL: warn if outside 18-72 (US bounds)
-#   - LONG_DECIMAL: warn if outside -180 to -64 (US bounds)
+# Airports: ALL NASR landing facilities are admitted (no row filtering).
+# Site type is carried via SITE_TYPE_CODE; facility use via facility_use.
+#   - FACILITY_USE_CODE (PU/PR) is read as the mapping source for facility_use
+#     and is NOT retained in the output.
+#   - Row count: warn if < 18000
+#   - LAT_DECIMAL / LONG_DECIMAL out-of-US-bounds: warn only, never filter
 #
+# Raw FAA source columns required to exist in APT_BASE.csv:
+airports_source_columns <- c(
+  "EFF_DATE", "SITE_NO", "SITE_TYPE_CODE", "STATE_CODE", "ARPT_ID",
+  "CITY", "COUNTRY_CODE", "STATE_NAME", "COUNTY_NAME", "ARPT_NAME",
+  "LAT_DEG", "LAT_MIN", "LAT_SEC", "LAT_HEMIS", "LAT_DECIMAL",
+  "LONG_DEG", "LONG_MIN", "LONG_SEC", "LONG_HEMIS", "LONG_DECIMAL",
+  "ELEV", "ELEV_METHOD_CODE", "MAG_VARN", "MAG_HEMIS", "MAG_VARN_YEAR",
+  "ICAO_ID", "FACILITY_USE_CODE"
+)
+
+# Output columns: raw FACILITY_USE_CODE is dropped, derived facility_use added.
 airports_columns <- c(
   "EFF_DATE", "SITE_NO", "SITE_TYPE_CODE", "STATE_CODE", "ARPT_ID",
   "CITY", "COUNTRY_CODE", "STATE_NAME", "COUNTY_NAME", "ARPT_NAME",
   "LAT_DEG", "LAT_MIN", "LAT_SEC", "LAT_HEMIS", "LAT_DECIMAL",
   "LONG_DEG", "LONG_MIN", "LONG_SEC", "LONG_HEMIS", "LONG_DECIMAL",
   "ELEV", "ELEV_METHOD_CODE", "MAG_VARN", "MAG_HEMIS", "MAG_VARN_YEAR",
-  "ICAO_ID"
+  "ICAO_ID", "facility_use"
 )
 
 # Navaids validation rules:
@@ -47,10 +59,31 @@ valid_nav_types <- c(
   "NDB", "NDB/DME", "TACAN", "UHF/NDB", "VOR", "VOR/DME", "VORTAC", "VOT"
 )
 
+#' Map FAA FACILITY_USE_CODE to a friendly label
+#'
+#' @param codes Character vector of FAA facility-use codes (PU/PR)
+#' @return Character vector of "public"/"private"; aborts on any other value
+#' @keywords internal
+map_facility_use <- function(codes) {
+  mapping <- c(PU = "public", PR = "private")
+  unknown <- setdiff(unique(codes), names(mapping))
+  if (length(unknown) > 0) {
+    rlang::abort(
+      c(
+        "Unexpected FACILITY_USE_CODE value(s)",
+        x = paste("Unknown:", paste(unknown, collapse = ", ")),
+        i = "Expected only PU or PR"
+      ),
+      class = "clean_data_facility_use_error"
+    )
+  }
+  unname(mapping[codes])
+}
+
 #' Clean airport data from FAA APT_BASE.csv
 #'
-#' Reads APT_BASE.csv, filters out 4-character airport IDs (military),
-#' and selects relevant columns.
+#' Reads APT_BASE.csv, admits all NASR landing facilities (no row filtering),
+#' maps FACILITY_USE_CODE to facility_use, and selects relevant columns.
 #'
 #' @param apt_base_path Path to APT_BASE.csv file
 #' @return Data frame with cleaned airport data
@@ -69,8 +102,8 @@ clean_airports <- function(apt_base_path) {
     check.names = FALSE
   )
 
-  # Verify required columns exist
-  missing_cols <- setdiff(airports_columns, names(airports_raw))
+  # Verify required source columns exist
+  missing_cols <- setdiff(airports_source_columns, names(airports_raw))
   if (length(missing_cols) > 0) {
     rlang::abort(
       c(
@@ -81,16 +114,15 @@ clean_airports <- function(apt_base_path) {
     )
   }
 
-  airports <- airports_raw[nchar(airports_raw$ARPT_ID) != 4, ]
-  airports <- airports[, airports_columns]
+  # Map facility-use code to friendly label (fail loud on unknown code)
+  airports_raw$facility_use <- map_facility_use(airports_raw$FACILITY_USE_CODE)
 
-  # Validate result is not empty
+  # No row filtering: admit all site types and all ID lengths
+  airports <- airports_raw[, airports_columns]
+
   if (nrow(airports) == 0) {
     rlang::abort(
-      c(
-        "No airports remaining after filtering",
-        i = "All records had 4-character ARPT_ID (military airports)"
-      ),
+      "No airports found in APT_BASE.csv",
       class = "clean_data_empty_result"
     )
   }

--- a/R/clean_data.R
+++ b/R/clean_data.R
@@ -202,6 +202,14 @@ validate_cleaned_data <- function(data,
       )
     }
 
+    # facility_use column must be present (fail loud; NULL would pass vacuously)
+    if (!"facility_use" %in% names(data)) {
+      rlang::abort(
+        "Column 'facility_use' is missing from airports data",
+        class = "validation_error"
+      )
+    }
+
     # facility_use must be one of the mapped labels (error - critical)
     if (!all(data$facility_use %in% c("public", "private"))) {
       rlang::abort(

--- a/R/clean_data.R
+++ b/R/clean_data.R
@@ -195,22 +195,22 @@ validate_cleaned_data <- function(data,
 
   if (schema_type == "airports") {
     # Check expected row count (warning only)
-    if (nrow(data) < 5000) {
+    if (nrow(data) < 18000) {
       rlang::warn(
-        paste("Expected at least 5000 airports, got", nrow(data)),
+        paste("Expected at least 18000 airports, got", nrow(data)),
         class = "validation_warning"
       )
     }
 
-    # Check ARPT_ID length (error - critical)
-    if (any(nchar(data$ARPT_ID) > 3)) {
+    # facility_use must be one of the mapped labels (error - critical)
+    if (!all(data$facility_use %in% c("public", "private"))) {
       rlang::abort(
-        "Found airports with ARPT_ID > 3 characters after filtering",
+        "facility_use contains values outside {public, private}",
         class = "validation_error"
       )
     }
 
-    # Check latitude range (warning only)
+    # Check latitude range (warning only - never filter; US territories)
     lat_valid <- data$LAT_DECIMAL >= 18 & data$LAT_DECIMAL <= 72
     if (!all(lat_valid, na.rm = TRUE)) {
       rlang::warn(
@@ -219,7 +219,7 @@ validate_cleaned_data <- function(data,
       )
     }
 
-    # Check longitude range (warning only)
+    # Check longitude range (warning only - never filter; US territories)
     long_valid <- data$LONG_DECIMAL >= -180 & data$LONG_DECIMAL <= -64
     if (!all(long_valid, na.rm = TRUE)) {
       rlang::warn(

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ This key is **read-only** - you can query all <!-- pipeline:airports_count -->5,
 
 This project provides a reusable backend platform that ingests publicly available FAA aeronautical reference data (airports and navaids), stores it in a Supabase-hosted Postgres database, and exposes it via a REST API. The platform supports multiple downstream projects requiring authoritative lookup of identifiers and coordinates.
 
+The `airports` table holds **all NASR landing facilities** (airports, heliports, seaplane bases, gliderports, balloonports, ultralight), not just public-use airports. Consumers distinguish them via `site_type_code` and `facility_use` (public/private).
+
 **Current Data:**
 - <!-- pipeline:airports_count -->5,305<!-- /pipeline:airports_count --> airports
 - <!-- pipeline:navaids_count -->1,634<!-- /pipeline:navaids_count --> navaids
@@ -234,12 +236,14 @@ plot(history$faa_date, history$navaids, type = "l")
 |--------|------|-------------|
 | arpt_id | TEXT | Airport identifier (e.g., "LAX") |
 | arpt_name | TEXT | Airport name |
+| facility_use | TEXT | Facility use: public or private |
 | city | TEXT | City |
 | state_code | TEXT | State code |
 | lat_decimal | NUMERIC | Latitude |
 | long_decimal | NUMERIC | Longitude |
 | elev | NUMERIC | Elevation (feet) |
 | icao_id | TEXT | ICAO identifier |
+| site_type_code | TEXT | Facility type: A=airport, H=heliport, C=seaplane, G=glider, B=balloon, U=ultralight |
 
 ### navaids
 | Column | Type | Description |

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -30,7 +30,8 @@ CREATE TABLE airports (
   mag_varn NUMERIC,
   mag_hemis TEXT,
   mag_varn_year INTEGER,
-  icao_id TEXT
+  icao_id TEXT,
+  facility_use TEXT
 );
 
 -- Create navaids table (lowercase column names)

--- a/tests/testthat/helper-setup.R
+++ b/tests/testthat/helper-setup.R
@@ -145,6 +145,7 @@ create_test_raw_data_dir <- function() {
    EFF_DATE = "12/19/2024",
    SITE_NO = c("00001", "00002", "00003", "00004"),
    SITE_TYPE_CODE = "A",
+   FACILITY_USE_CODE = "PU",
    STATE_CODE = c("CA", "TX", "NY", "FL"),
    ARPT_ID = c("LAX", "DFW", "JFK", "KMIA"),
    CITY = c("Los Angeles", "Dallas", "New York", "Miami"),

--- a/tests/testthat/helper-setup.R
+++ b/tests/testthat/helper-setup.R
@@ -81,7 +81,8 @@ sample_airports <- function(n = 3) {
    mag_varn = rep(c(13.0, 4.0, -13.0), length.out = n),
    mag_hemis = rep(c("E", "W"), length.out = n),
    mag_varn_year = 2020L,
-   icao_id = sprintf("KTS%d", seq_len(n))
+   icao_id = sprintf("KTS%d", seq_len(n)),
+   facility_use = rep(c("public", "private"), length.out = n)
  )
 }
 

--- a/tests/testthat/test-clean_data.R
+++ b/tests/testthat/test-clean_data.R
@@ -11,52 +11,117 @@ test_that("clean_airports validates file path exists", {
   )
 })
 
-test_that("clean_airports filters out 4-character ARPT_IDs", {
-  # Create temp test data
+test_that("clean_airports retains 4-char ARPT_IDs and all site types", {
   temp_dir <- withr::local_tempdir()
   temp_file <- file.path(temp_dir, "APT_BASE.csv")
 
-  # Create sample data with mix of 3 and 4 character IDs
   test_data <- data.frame(stringsAsFactors = FALSE,
     EFF_DATE = "12/19/2024",
-    SITE_NO = c("00001", "00002", "00003", "00004"),
-    SITE_TYPE_CODE = "A",
-    STATE_CODE = c("CA", "TX", "NY", "FL"),
-    ARPT_ID = c("LAX", "DFW", "JFK", "KMIA"),  # KMIA is 4 chars
-    CITY = c("Los Angeles", "Dallas", "New York", "Miami"),
+    SITE_NO = c("00001", "00002", "00003"),
+    SITE_TYPE_CODE = c("A", "H", "A"),
+    STATE_CODE = c("CA", "AL", "AL"),
+    ARPT_ID = c("LAX", "0AL1", "AL10"),  # 4-char private LID AL10 retained
+    CITY = c("Los Angeles", "Helitown", "Gurley"),
     COUNTRY_CODE = "US",
-    STATE_NAME = c("California", "Texas", "New York", "Florida"),
-    COUNTY_NAME = c("Los Angeles", "Tarrant", "Queens", "Miami-Dade"),
-    ARPT_NAME = c("Los Angeles Intl", "Dallas Fort Worth", "JFK Intl", "Miami"),
-    LAT_DEG = c(33L, 32L, 40L, 25L),
-    LAT_MIN = c(56L, 53L, 38L, 47L),
-    LAT_SEC = c("33.00", "35.00", "23.00", "36.00"),
-    LAT_HEMIS = "N",
-    LAT_DECIMAL = c(33.94, 32.89, 40.64, 25.79),
-    LONG_DEG = c(118L, 97L, 73L, 80L),
-    LONG_MIN = c(24L, 2L, 46L, 17L),
-    LONG_SEC = c("29.00", "44.00", "44.00", "25.00"),
-    LONG_HEMIS = "W",
-    LONG_DECIMAL = c(-118.41, -97.05, -73.78, -80.29),
-    ELEV = c(128, 607, 13, 9),
+    STATE_NAME = c("California", "Alabama", "Alabama"),
+    COUNTY_NAME = c("Los Angeles", "X", "Madison"),
+    ARPT_NAME = c("Los Angeles Intl", "Helipad", "Frerichs"),
+    LAT_DEG = c(33L, 34L, 34L), LAT_MIN = c(56L, 0L, 42L),
+    LAT_SEC = c("33.00", "0.00", "0.00"), LAT_HEMIS = "N",
+    LAT_DECIMAL = c(33.94, 34.0, 34.7),
+    LONG_DEG = c(118L, 86L, 86L), LONG_MIN = c(24L, 0L, 21L),
+    LONG_SEC = c("29.00", "0.00", "0.00"), LONG_HEMIS = "W",
+    LONG_DECIMAL = c(-118.41, -86.0, -86.35),
+    ELEV = c(128, 600, 700),
     ELEV_METHOD_CODE = "S",
-    MAG_VARN = c(13.0, 4.0, -13.0, -5.0),
-    MAG_HEMIS = c("E", "E", "W", "W"),
-    MAG_VARN_YEAR = 2020L,
-    ICAO_ID = c("KLAX", "KDFW", "KJFK", "KMIA")
+    MAG_VARN = c(13.0, 2.0, 2.0), MAG_HEMIS = "W", MAG_VARN_YEAR = 2020L,
+    ICAO_ID = c("KLAX", "", ""),
+    FACILITY_USE_CODE = c("PU", "PR", "PR")
   )
-
   write.csv(test_data, temp_file, row.names = FALSE)
 
   result <- clean_airports(temp_file)
 
-  # KMIA (4 chars) should be filtered out
-  expect_false("KMIA" %in% result$ARPT_ID)
+  expect_true("AL10" %in% result$ARPT_ID)   # 4-char private LID retained
+  expect_true("0AL1" %in% result$ARPT_ID)   # heliport retained
+  expect_equal(nrow(result), 3)             # no rows dropped
+})
 
-  # LAX, DFW, JFK (3 chars) should remain
-  expect_true(all(c("LAX", "DFW", "JFK") %in% result$ARPT_ID))
+test_that("clean_airports maps PU/PR to public/private", {
+  temp_dir <- withr::local_tempdir()
+  temp_file <- file.path(temp_dir, "APT_BASE.csv")
+  test_data <- data.frame(stringsAsFactors = FALSE,
+    EFF_DATE = "12/19/2024", SITE_NO = c("00001", "00002"),
+    SITE_TYPE_CODE = "A", STATE_CODE = c("CA", "AL"),
+    ARPT_ID = c("LAX", "AL10"), CITY = c("Los Angeles", "Gurley"),
+    COUNTRY_CODE = "US", STATE_NAME = c("California", "Alabama"),
+    COUNTY_NAME = c("Los Angeles", "Madison"),
+    ARPT_NAME = c("Los Angeles Intl", "Frerichs"),
+    LAT_DEG = c(33L, 34L), LAT_MIN = c(56L, 42L),
+    LAT_SEC = c("33.00", "0.00"), LAT_HEMIS = "N",
+    LAT_DECIMAL = c(33.94, 34.7),
+    LONG_DEG = c(118L, 86L), LONG_MIN = c(24L, 21L),
+    LONG_SEC = c("29.00", "0.00"), LONG_HEMIS = "W",
+    LONG_DECIMAL = c(-118.41, -86.35),
+    ELEV = c(128, 700), ELEV_METHOD_CODE = "S",
+    MAG_VARN = c(13.0, 2.0), MAG_HEMIS = "W", MAG_VARN_YEAR = 2020L,
+    ICAO_ID = c("KLAX", ""), FACILITY_USE_CODE = c("PU", "PR")
+  )
+  write.csv(test_data, temp_file, row.names = FALSE)
 
-  expect_equal(nrow(result), 3)
+  result <- clean_airports(temp_file)
+
+  expect_equal(result$facility_use[result$ARPT_ID == "LAX"], "public")
+  expect_equal(result$facility_use[result$ARPT_ID == "AL10"], "private")
+})
+
+test_that("clean_airports output has facility_use, not facility_use_code", {
+  temp_dir <- withr::local_tempdir()
+  temp_file <- file.path(temp_dir, "APT_BASE.csv")
+  test_data <- data.frame(stringsAsFactors = FALSE,
+    EFF_DATE = "12/19/2024", SITE_NO = "00001", SITE_TYPE_CODE = "A",
+    STATE_CODE = "CA", ARPT_ID = "LAX", CITY = "Los Angeles",
+    COUNTRY_CODE = "US", STATE_NAME = "California", COUNTY_NAME = "LA",
+    ARPT_NAME = "Los Angeles Intl",
+    LAT_DEG = 33L, LAT_MIN = 56L, LAT_SEC = "33.00", LAT_HEMIS = "N",
+    LAT_DECIMAL = 33.94,
+    LONG_DEG = 118L, LONG_MIN = 24L, LONG_SEC = "29.00", LONG_HEMIS = "W",
+    LONG_DECIMAL = -118.41,
+    ELEV = 128, ELEV_METHOD_CODE = "S",
+    MAG_VARN = 13.0, MAG_HEMIS = "E", MAG_VARN_YEAR = 2020L,
+    ICAO_ID = "KLAX", FACILITY_USE_CODE = "PU"
+  )
+  write.csv(test_data, temp_file, row.names = FALSE)
+
+  result <- clean_airports(temp_file)
+
+  expect_true("facility_use" %in% names(result))
+  expect_false("facility_use_code" %in% tolower(names(result)))
+  expect_false("FACILITY_USE_CODE" %in% names(result))
+})
+
+test_that("clean_airports aborts on unknown facility-use code", {
+  temp_dir <- withr::local_tempdir()
+  temp_file <- file.path(temp_dir, "APT_BASE.csv")
+  test_data <- data.frame(stringsAsFactors = FALSE,
+    EFF_DATE = "12/19/2024", SITE_NO = "00001", SITE_TYPE_CODE = "A",
+    STATE_CODE = "CA", ARPT_ID = "LAX", CITY = "Los Angeles",
+    COUNTRY_CODE = "US", STATE_NAME = "California", COUNTY_NAME = "LA",
+    ARPT_NAME = "Los Angeles Intl",
+    LAT_DEG = 33L, LAT_MIN = 56L, LAT_SEC = "33.00", LAT_HEMIS = "N",
+    LAT_DECIMAL = 33.94,
+    LONG_DEG = 118L, LONG_MIN = 24L, LONG_SEC = "29.00", LONG_HEMIS = "W",
+    LONG_DECIMAL = -118.41,
+    ELEV = 128, ELEV_METHOD_CODE = "S",
+    MAG_VARN = 13.0, MAG_HEMIS = "E", MAG_VARN_YEAR = 2020L,
+    ICAO_ID = "KLAX", FACILITY_USE_CODE = "ZZ"  # invalid code
+  )
+  write.csv(test_data, temp_file, row.names = FALSE)
+
+  expect_error(
+    clean_airports(temp_file),
+    class = "clean_data_facility_use_error"
+  )
 })
 
 test_that("clean_airports returns expected columns", {
@@ -83,6 +148,7 @@ test_that("clean_airports returns expected columns", {
     ELEV_METHOD_CODE = "S",
     MAG_VARN = 13.0, MAG_HEMIS = "E", MAG_VARN_YEAR = 2020L,
     ICAO_ID = "KLAX",
+    FACILITY_USE_CODE = "PU",
     EXTRA_COL = "should be dropped"  # Extra column not in schema
   )
 

--- a/tests/testthat/test-clean_data.R
+++ b/tests/testthat/test-clean_data.R
@@ -231,38 +231,47 @@ test_that("validate_cleaned_data requires valid schema_type", {
   )
 })
 
-test_that("validate_cleaned_data checks airports have valid ARPT_ID length", {
-  # Create data that would fail validation (has 4-char ARPT_ID)
-  data <- data.frame(stringsAsFactors = FALSE,
-    EFF_DATE = as.Date("2024-12-19"),
-    SITE_NO = "00001",
-    SITE_TYPE_CODE = "A",
-    STATE_CODE = "CA",
-    ARPT_ID = "KMIA",  # 4 characters - should fail
-    CITY = "Miami",
-    COUNTRY_CODE = "US",
-    STATE_NAME = "Florida",
-    COUNTY_NAME = "Miami-Dade",
-    ARPT_NAME = "Miami Intl",
-    LAT_DEG = 25L, LAT_MIN = 47L, LAT_SEC = "36.00", LAT_HEMIS = "N",
-    LAT_DECIMAL = 25.79,
-    LONG_DEG = 80L, LONG_MIN = 17L, LONG_SEC = "25.00", LONG_HEMIS = "W",
-    LONG_DECIMAL = -80.29,
-    ELEV = 9,
-    ELEV_METHOD_CODE = "S",
-    MAG_VARN = -5.0, MAG_HEMIS = "W", MAG_VARN_YEAR = 2020L,
-    ICAO_ID = "KMIA"
-  )
+test_that("validate_cleaned_data accepts 4-char ARPT_IDs", {
+  data <- sample_airports(3)
+  names(data) <- toupper(names(data))
+  names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
+  data$ARPT_ID <- c("LAX", "AL10", "0AL1")  # mixed 3/4-char now valid
 
-  # Wrap in expect_warning to capture the expected "< 5000 airports" warning
-  # that fires before the ARPT_ID length error
-  expect_warning(
-    expect_error(
-      validate_cleaned_data(data, "airports"),
-      class = "validation_error"
-    ),
-    class = "validation_warning"
+  result <- withCallingHandlers(
+    validate_cleaned_data(data, "airports"),
+    validation_warning = function(w) invokeRestart("muffleWarning")
   )
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 3)
+})
+
+test_that("validate_cleaned_data aborts on invalid facility_use", {
+  data <- sample_airports(3)
+  names(data) <- toupper(names(data))
+  names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
+  data$facility_use <- c("public", "private", "bogus")
+
+  expect_error(
+    withCallingHandlers(
+      validate_cleaned_data(data, "airports"),
+      validation_warning = function(w) invokeRestart("muffleWarning")
+    ),
+    class = "validation_error"
+  )
+})
+
+test_that("validate_cleaned_data warns but does not drop out-of-range coords", {
+  data <- sample_airports(2)
+  names(data) <- toupper(names(data))
+  names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
+  data$LAT_DECIMAL <- c(13.4, 33.94)     # Guam-like latitude (< 18) included
+  data$LONG_DECIMAL <- c(144.8, -118.4)  # Guam-like longitude (> -64) included
+
+  result <- withCallingHandlers(
+    validate_cleaned_data(data, "airports"),
+    validation_warning = function(w) invokeRestart("muffleWarning")
+  )
+  expect_equal(nrow(result), 2)  # nothing filtered
 })
 
 test_that("find_raw_data_dirs validates directory exists", {

--- a/tests/testthat/test-clean_data.R
+++ b/tests/testthat/test-clean_data.R
@@ -243,6 +243,22 @@ test_that("validate_cleaned_data accepts 4-char ARPT_IDs", {
   )
   expect_s3_class(result, "data.frame")
   expect_equal(nrow(result), 3)
+  expect_true(all(c("AL10", "0AL1") %in% result$ARPT_ID))
+})
+
+test_that("validate_cleaned_data aborts when facility_use column is missing", {
+  data <- sample_airports(3)
+  names(data) <- toupper(names(data))
+  names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
+  data$facility_use <- NULL  # remove the column entirely
+
+  expect_error(
+    withCallingHandlers(
+      validate_cleaned_data(data, "airports"),
+      validation_warning = function(w) invokeRestart("muffleWarning")
+    ),
+    class = "validation_error"
+  )
 })
 
 test_that("validate_cleaned_data aborts on invalid facility_use", {

--- a/tests/testthat/test-push_to_supabase.R
+++ b/tests/testthat/test-push_to_supabase.R
@@ -208,3 +208,23 @@ test_that("clear_table targets correct table in URL", {
     )
   })
 })
+
+test_that("push_to_supabase body includes facility_use", {
+  skip_if_not_installed("httptest2")
+  source_project_file("push_to_supabase.R")
+
+  withr::local_envvar(
+    SUPABASE_API_KEY = MOCK_SUPABASE_API_KEY,
+    SUPABASE_URL = MOCK_SUPABASE_URL
+  )
+
+  data <- sample_airports(1)
+
+  httptest2::without_internet({
+    expect_error(
+      push_to_supabase("airports", data),
+      regexp = '"facility_use"',
+      fixed = TRUE
+    )
+  })
+})


### PR DESCRIPTION
Closes #14.

## What

- Remove the `nchar(ARPT_ID) != 4` filter in `R/clean_data.R`; admit **all** NASR landing facilities (~19,410: airports, heliports, seaplane bases, gliderports, balloonports, ultralight). Facility kind is carried by the existing `site_type_code`.
- Add a `facility_use` column (`public`/`private`), mapped from FAA `FACILITY_USE_CODE` via a fail-loud `map_facility_use()` (aborts on any code outside `{PU, PR}`). The raw `FACILITY_USE_CODE` is **dropped from output** — leaving it in would serialize as an unknown `facility_use_code` column and 400 the batch insert.
- Relax `validate_cleaned_data()`: remove the `ARPT_ID > 3` abort (4-char LIDs are valid), row-count warn threshold `5000 → 18000`, add a `facility_use` presence + value invariant (fail loud), and keep coordinate-bounds checks **warning-only** — no row filtering (US territories legitimately fall outside the CONUS box).
- `sql/create_tables.sql` gains `facility_use TEXT` (canonical fresh-setup schema; grants are table-level and already cover it).
- `R/push_to_supabase.R` is **unchanged** (column-agnostic); a passthrough test guards that `facility_use` reaches the batch body.
- README schema table + coverage framing updated. Count markers are left to auto-update on the deploy pipeline run.

## Verified locally (real NASR 2026-05-14 `APT_BASE.csv`)

- 19,410 rows admitted; `facility_use` = private 14,240 / public 5,170.
- `FACILITY_USE_CODE` absent from output; `facility_use` present.
- All site types retained (A/B/C/G/H/U) — no coverage regression vs the current public-only DB.
- `AL10` (Frerichs, Gurley AL) resolves as a private airport — the gap this closes.
- Full suite: `FAIL 0 | PASS 113 | SKIP 1` (pre-existing CRAN skip). All R/test lines ≤110.

## Deploy — DO NOT run without separate, explicitly-coordinated go-ahead

The live Supabase DB backs an in-flight FAA UAS-sighting IE experiment. Deploy is:

1. `ALTER TABLE airports ADD COLUMN facility_use TEXT;` — **NOT** DROP/recreate (preserves `navaids`, no long empty window on the shared prod table). PostgREST auto-reloads its schema cache on DDL.
2. Forced pipeline run (clear + insert) — briefly empties the table mid-run (~39 batches), so IE lookups are dark for that window.

Repopulation changes the IE lookup surface (Gurley → Frerichs starts resolving; ~14k facilities added). Hold until timing is coordinated with the owner.

## Review

Full manual review requested. No merge without review. No live-DB change has been made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
