### PR TITLE
chore(ci): add lint+test gate; make tests/ lint-clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  RENV_CONFIG_REPOS_OVERRIDE: 'https://packagemanager.posit.co/cran/__linux__/noble/latest'
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libcurl4-openssl-dev \
+            libfontconfig1-dev \
+            libfreetype6-dev \
+            libx11-dev \
+            pandoc
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.5'
+
+      - name: Setup renv
+        uses: r-lib/actions/setup-renv@v2
+
+      - name: Install lintr (pinned; not in renv.lock by design)
+        run: Rscript -e 'renv::install("lintr@3.3.0.1")'
+
+      - name: Lint R/ and tests/
+        run: |
+          Rscript -e '
+          lints_r <- lintr::lint_dir("R")
+          lints_tests <- lintr::lint_dir("tests")
+          if (length(lints_r) + length(lints_tests) > 0) {
+            print(lints_r)
+            print(lints_tests)
+            quit(status = 1)
+          }
+          cat("0 lints\n")
+          '
+
+      - name: Run test suite
+        run: Rscript -e 'testthat::test_dir("tests/testthat")'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         uses: r-lib/actions/setup-renv@v2
 
       - name: Install lintr (pinned; not in renv.lock by design)
-        run: Rscript -e 'renv::install("lintr@3.3.0.1")'
+        run: Rscript -e 'renv::install("lintr@3.3.0-1")'
 
       - name: Lint R/ and tests/
         run: |

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -7,16 +7,16 @@ library(testthat)
 # Source all R files to make functions available
 r_dir <- file.path(dirname(dirname(getwd())), "R")
 if (dir.exists("R")) {
- r_dir <- "R"
+  r_dir <- "R"
 } else if (dir.exists("../R")) {
- r_dir <- "../R"
+  r_dir <- "../R"
 } else if (dir.exists("../../R")) {
- r_dir <- "../../R"
+  r_dir <- "../../R"
 }
 
 # Run tests
 test_dir(
- path = "tests/testthat",
- reporter = "progress",
- stop_on_failure = FALSE
+  path = "tests/testthat",
+  reporter = "progress",
+  stop_on_failure = FALSE
 )

--- a/tests/testthat/helper-setup.R
+++ b/tests/testthat/helper-setup.R
@@ -17,189 +17,194 @@ if (requireNamespace("httptest2", quietly = TRUE)) {
 # --- Source R files from project ---
 # Determine project root from test directory
 project_root <- function() {
- # When running from tests/testthat, go up two levels
- # When running from project root, stay there
- candidates <- c(
-   ".",
-   "..",
-   "../..",
-   file.path(getwd(), "../.."),
-   Sys.getenv("AIRPORTS_NAVAIDS_ROOT", unset = NA)
- )
+  # When running from tests/testthat, go up two levels
+  # When running from project root, stay there
+  candidates <- c(
+    ".",
+    "..",
+    "../..",
+    file.path(getwd(), "../.."),
+    Sys.getenv("AIRPORTS_NAVAIDS_ROOT", unset = NA)
+  )
 
- for (path in candidates) {
-   if (!is.na(path) && file.exists(file.path(path, "R", "push_to_supabase.R")))
-     return(normalizePath(path))
- }
+  for (path in candidates) {
+    if (!is.na(path) && file.exists(file.path(path, "R", "push_to_supabase.R"))) {
+      return(normalizePath(path))
+    }
+  }
 
- rlang::abort("Could not find project root. Set AIRPORTS_NAVAIDS_ROOT env var.")
+  rlang::abort("Could not find project root. Set AIRPORTS_NAVAIDS_ROOT env var.")
 }
 
 source_project_file <- function(filename) {
- source(file.path(project_root(), "R", filename), local = FALSE)
+  source(file.path(project_root(), "R", filename), local = FALSE)
 }
 
 # --- Mock Supabase credentials ---
 # Use fake credentials for testing (never real keys)
-MOCK_SUPABASE_API_KEY <- "test_key_not_real_do_not_use"
-MOCK_SUPABASE_URL <- "https://test-project.supabase.co"
+mock_supabase_api_key <- "test_key_not_real_do_not_use"
+mock_supabase_url <- "https://test-project.supabase.co"
 
 # Set mock env vars for testing (will be restored after each test via withr)
 setup_mock_credentials <- function() {
- withr::local_envvar(
-   SUPABASE_API_KEY = MOCK_SUPABASE_API_KEY,
-   SUPABASE_URL = MOCK_SUPABASE_URL
- )
+  withr::local_envvar(
+    SUPABASE_API_KEY = mock_supabase_api_key,
+    SUPABASE_URL = mock_supabase_url
+  )
 }
 
 # --- Sample data fixtures ---
 # Minimal valid airports tibble matching expected schema
 sample_airports <- function(n = 3) {
- data.frame(stringsAsFactors = FALSE,
-   eff_date = as.Date("2024-12-19"),
-   site_no = sprintf("TEST%04d", seq_len(n)),
-   site_type_code = "A",
-   state_code = rep(c("CA", "TX", "NY"), length.out = n),
-   arpt_id = sprintf("TS%d", seq_len(n)),
-   city = sprintf("Test City %d", seq_len(n)),
-   country_code = "US",
-   state_name = rep(c("California", "Texas", "New York"), length.out = n),
-   county_name = sprintf("Test County %d", seq_len(n)),
-   arpt_name = sprintf("Test Airport %d", seq_len(n)),
-   lat_deg = rep(34L, n),
-   lat_min = rep(3L, n),
-   lat_sec = rep(c("33.0000", "35.0000", "23.0000"), length.out = n),
-   lat_hemis = "N",
-   lat_decimal = rep(c(33.94, 32.89, 40.64), length.out = n),
-   long_deg = rep(118L, n),
-   long_min = rep(14L, n),
-   long_sec = rep(c("29.0000", "44.0000", "44.0000"), length.out = n),
-   long_hemis = "W",
-   long_decimal = rep(c(-118.41, -97.05, -73.78), length.out = n),
-   elev = rep(c(128, 607, 13), length.out = n),
-   elev_method_code = "S",
-   mag_varn = rep(c(13.0, 4.0, -13.0), length.out = n),
-   mag_hemis = rep(c("E", "W"), length.out = n),
-   mag_varn_year = 2020L,
-   icao_id = sprintf("KTS%d", seq_len(n)),
-   facility_use = rep(c("public", "private"), length.out = n)
- )
+  data.frame(
+    stringsAsFactors = FALSE,
+    eff_date = as.Date("2024-12-19"),
+    site_no = sprintf("TEST%04d", seq_len(n)),
+    site_type_code = "A",
+    state_code = rep(c("CA", "TX", "NY"), length.out = n),
+    arpt_id = sprintf("TS%d", seq_len(n)),
+    city = sprintf("Test City %d", seq_len(n)),
+    country_code = "US",
+    state_name = rep(c("California", "Texas", "New York"), length.out = n),
+    county_name = sprintf("Test County %d", seq_len(n)),
+    arpt_name = sprintf("Test Airport %d", seq_len(n)),
+    lat_deg = rep(34L, n),
+    lat_min = rep(3L, n),
+    lat_sec = rep(c("33.0000", "35.0000", "23.0000"), length.out = n),
+    lat_hemis = "N",
+    lat_decimal = rep(c(33.94, 32.89, 40.64), length.out = n),
+    long_deg = rep(118L, n),
+    long_min = rep(14L, n),
+    long_sec = rep(c("29.0000", "44.0000", "44.0000"), length.out = n),
+    long_hemis = "W",
+    long_decimal = rep(c(-118.41, -97.05, -73.78), length.out = n),
+    elev = rep(c(128, 607, 13), length.out = n),
+    elev_method_code = "S",
+    mag_varn = rep(c(13.0, 4.0, -13.0), length.out = n),
+    mag_hemis = rep(c("E", "W"), length.out = n),
+    mag_varn_year = 2020L,
+    icao_id = sprintf("KTS%d", seq_len(n)),
+    facility_use = rep(c("public", "private"), length.out = n)
+  )
 }
 
 # Minimal valid navaids tibble matching expected schema
 sample_navaids <- function(n = 3) {
- data.frame(stringsAsFactors = FALSE,
-   eff_date = as.Date("2024-12-19"),
-   nav_id = sprintf("TST%d", seq_len(n)),
-   nav_type = rep(c("VOR", "NDB", "VORTAC"), length.out = n),
-   state_code = rep(c("CA", "TX", "NY"), length.out = n),
-   city = sprintf("Test City %d", seq_len(n)),
-   country_code = "US",
-   name = sprintf("Test Navaid %d", seq_len(n)),
-   state_name = rep(c("California", "Texas", "New York"), length.out = n),
-   region_code = "AWP",
-   lat_hemis = "N",
-   lat_deg = rep(34L, n),
-   lat_min = rep(3L, n),
-   lat_sec = rep(c("33.0000", "35.0000", "23.0000"), length.out = n),
-   lat_decimal = rep(c(33.94, 32.89, 40.64), length.out = n),
-   long_hemis = "W",
-   long_deg = rep(118L, n),
-   long_min = rep(14L, n),
-   long_sec = rep(c("29.0000", "44.0000", "44.0000"), length.out = n),
-   long_decimal = rep(c(-118.41, -97.05, -73.78), length.out = n),
-   elev = rep(c(128, 607, 13), length.out = n),
-   mag_varn = rep(c(13.0, 4.0, -13.0), length.out = n),
-   mag_varn_hemis = rep(c("E", "W"), length.out = n),
-   mag_varn_year = 2020L,
-   alt_code = "LOW"
- )
+  data.frame(
+    stringsAsFactors = FALSE,
+    eff_date = as.Date("2024-12-19"),
+    nav_id = sprintf("TST%d", seq_len(n)),
+    nav_type = rep(c("VOR", "NDB", "VORTAC"), length.out = n),
+    state_code = rep(c("CA", "TX", "NY"), length.out = n),
+    city = sprintf("Test City %d", seq_len(n)),
+    country_code = "US",
+    name = sprintf("Test Navaid %d", seq_len(n)),
+    state_name = rep(c("California", "Texas", "New York"), length.out = n),
+    region_code = "AWP",
+    lat_hemis = "N",
+    lat_deg = rep(34L, n),
+    lat_min = rep(3L, n),
+    lat_sec = rep(c("33.0000", "35.0000", "23.0000"), length.out = n),
+    lat_decimal = rep(c(33.94, 32.89, 40.64), length.out = n),
+    long_hemis = "W",
+    long_deg = rep(118L, n),
+    long_min = rep(14L, n),
+    long_sec = rep(c("29.0000", "44.0000", "44.0000"), length.out = n),
+    long_decimal = rep(c(-118.41, -97.05, -73.78), length.out = n),
+    elev = rep(c(128, 607, 13), length.out = n),
+    mag_varn = rep(c(13.0, 4.0, -13.0), length.out = n),
+    mag_varn_hemis = rep(c("E", "W"), length.out = n),
+    mag_varn_year = 2020L,
+    alt_code = "LOW"
+  )
 }
 
 # --- HTTP mock utilities ---
 # Create a mock HTTP response for testing push_to_supabase
 mock_http_response <- function(status_code = 200, body = "[]") {
- structure(
-   list(
-     status_code = status_code,
-     headers = list(`content-type` = "application/json"),
-     body = charToRaw(body)
-   ),
-   class = "httr2_response"
- )
+  structure(
+    list(
+      status_code = status_code,
+      headers = list(`content-type` = "application/json"),
+      body = charToRaw(body)
+    ),
+    class = "httr2_response"
+  )
 }
 
 # --- Temp directory utilities ---
 # Create a temp directory with sample CSV files for testing clean_data.R
 create_test_raw_data_dir <- function() {
- temp_dir <- withr::local_tempdir(pattern = "faa_test_")
+  temp_dir <- withr::local_tempdir(pattern = "faa_test_")
 
- # Create APT and NAV subdirectories
- apt_dir <- file.path(temp_dir, "19_DEC_2024_APT_CSV")
- nav_dir <- file.path(temp_dir, "19_DEC_2024_NAV_CSV")
- dir.create(apt_dir)
- dir.create(nav_dir)
+  # Create APT and NAV subdirectories
+  apt_dir <- file.path(temp_dir, "19_DEC_2024_APT_CSV")
+  nav_dir <- file.path(temp_dir, "19_DEC_2024_NAV_CSV")
+  dir.create(apt_dir)
+  dir.create(nav_dir)
 
- # Write sample APT_BASE.csv
- apt_data <- data.frame(stringsAsFactors = FALSE,
-   EFF_DATE = "12/19/2024",
-   SITE_NO = c("00001", "00002", "00003", "00004"),
-   SITE_TYPE_CODE = "A",
-   FACILITY_USE_CODE = "PU",
-   STATE_CODE = c("CA", "TX", "NY", "FL"),
-   ARPT_ID = c("LAX", "DFW", "JFK", "KMIA"),
-   CITY = c("Los Angeles", "Dallas", "New York", "Miami"),
-   COUNTRY_CODE = "US",
-   STATE_NAME = c("California", "Texas", "New York", "Florida"),
-   COUNTY_NAME = c("Los Angeles", "Tarrant", "Queens", "Miami-Dade"),
-   ARPT_NAME = c("Los Angeles Intl", "Dallas Fort Worth", "JFK Intl", "Miami Intl"),
-   LAT_DEG = c(33L, 32L, 40L, 25L),
-   LAT_MIN = c(56L, 53L, 38L, 47L),
-   LAT_SEC = c("33.0000", "35.0000", "23.0000", "36.0000"),
-   LAT_HEMIS = "N",
-   LAT_DECIMAL = c(33.9425, 32.8931, 40.6398, 25.7933),
-   LONG_DEG = c(118L, 97L, 73L, 80L),
-   LONG_MIN = c(24L, 2L, 46L, 17L),
-   LONG_SEC = c("29.0000", "44.0000", "44.0000", "25.0000"),
-   LONG_HEMIS = "W",
-   LONG_DECIMAL = c(-118.4081, -97.0456, -73.7789, -80.2903),
-   ELEV = c(128, 607, 13, 9),
-   ELEV_METHOD_CODE = "S",
-   MAG_VARN = c(13.0, 4.0, -13.0, -5.0),
-   MAG_HEMIS = c("E", "E", "W", "W"),
-   MAG_VARN_YEAR = 2020L,
-   ICAO_ID = c("KLAX", "KDFW", "KJFK", "KMIA")
- )
- write.csv(apt_data, file.path(apt_dir, "APT_BASE.csv"), row.names = FALSE)
+  # Write sample APT_BASE.csv
+  apt_data <- data.frame(
+    stringsAsFactors = FALSE,
+    EFF_DATE = "12/19/2024",
+    SITE_NO = c("00001", "00002", "00003", "00004"),
+    SITE_TYPE_CODE = "A",
+    FACILITY_USE_CODE = "PU",
+    STATE_CODE = c("CA", "TX", "NY", "FL"),
+    ARPT_ID = c("LAX", "DFW", "JFK", "KMIA"),
+    CITY = c("Los Angeles", "Dallas", "New York", "Miami"),
+    COUNTRY_CODE = "US",
+    STATE_NAME = c("California", "Texas", "New York", "Florida"),
+    COUNTY_NAME = c("Los Angeles", "Tarrant", "Queens", "Miami-Dade"),
+    ARPT_NAME = c("Los Angeles Intl", "Dallas Fort Worth", "JFK Intl", "Miami Intl"),
+    LAT_DEG = c(33L, 32L, 40L, 25L),
+    LAT_MIN = c(56L, 53L, 38L, 47L),
+    LAT_SEC = c("33.0000", "35.0000", "23.0000", "36.0000"),
+    LAT_HEMIS = "N",
+    LAT_DECIMAL = c(33.9425, 32.8931, 40.6398, 25.7933),
+    LONG_DEG = c(118L, 97L, 73L, 80L),
+    LONG_MIN = c(24L, 2L, 46L, 17L),
+    LONG_SEC = c("29.0000", "44.0000", "44.0000", "25.0000"),
+    LONG_HEMIS = "W",
+    LONG_DECIMAL = c(-118.4081, -97.0456, -73.7789, -80.2903),
+    ELEV = c(128, 607, 13, 9),
+    ELEV_METHOD_CODE = "S",
+    MAG_VARN = c(13.0, 4.0, -13.0, -5.0),
+    MAG_HEMIS = c("E", "E", "W", "W"),
+    MAG_VARN_YEAR = 2020L,
+    ICAO_ID = c("KLAX", "KDFW", "KJFK", "KMIA")
+  )
+  write.csv(apt_data, file.path(apt_dir, "APT_BASE.csv"), row.names = FALSE)
 
- # Write sample NAV_BASE.csv
- nav_data <- data.frame(stringsAsFactors = FALSE,
-   EFF_DATE = "12/19/2024",
-   NAV_ID = c("LAX", "DFW", "JFK"),
-   NAV_TYPE = c("VOR", "VORTAC", "VOR"),
-   STATE_CODE = c("CA", "TX", "NY"),
-   CITY = c("Los Angeles", "Dallas", "New York"),
-   COUNTRY_CODE = "US",
-   NAME = c("Los Angeles VOR", "Cowboy VORTAC", "Kennedy VOR"),
-   STATE_NAME = c("California", "Texas", "New York"),
-   REGION_CODE = c("AWP", "ASW", "AEA"),
-   LAT_HEMIS = "N",
-   LAT_DEG = c(33L, 32L, 40L),
-   LAT_MIN = c(56L, 53L, 38L),
-   LAT_SEC = c("33.0000", "35.0000", "23.0000"),
-   LAT_DECIMAL = c(33.9425, 32.8931, 40.6398),
-   LONG_HEMIS = "W",
-   LONG_DEG = c(118L, 97L, 73L),
-   LONG_MIN = c(24L, 2L, 46L),
-   LONG_SEC = c("29.0000", "44.0000", "44.0000"),
-   LONG_DECIMAL = c(-118.4081, -97.0456, -73.7789),
-   ELEV = c(128, 607, 13),
-   MAG_VARN = c(13.0, 4.0, -13.0),
-   MAG_VARN_HEMIS = c("E", "E", "W"),
-   MAG_VARN_YEAR = 2020L,
-   ALT_CODE = "LOW"
- )
- write.csv(nav_data, file.path(nav_dir, "NAV_BASE.csv"), row.names = FALSE)
+  # Write sample NAV_BASE.csv
+  nav_data <- data.frame(
+    stringsAsFactors = FALSE,
+    EFF_DATE = "12/19/2024",
+    NAV_ID = c("LAX", "DFW", "JFK"),
+    NAV_TYPE = c("VOR", "VORTAC", "VOR"),
+    STATE_CODE = c("CA", "TX", "NY"),
+    CITY = c("Los Angeles", "Dallas", "New York"),
+    COUNTRY_CODE = "US",
+    NAME = c("Los Angeles VOR", "Cowboy VORTAC", "Kennedy VOR"),
+    STATE_NAME = c("California", "Texas", "New York"),
+    REGION_CODE = c("AWP", "ASW", "AEA"),
+    LAT_HEMIS = "N",
+    LAT_DEG = c(33L, 32L, 40L),
+    LAT_MIN = c(56L, 53L, 38L),
+    LAT_SEC = c("33.0000", "35.0000", "23.0000"),
+    LAT_DECIMAL = c(33.9425, 32.8931, 40.6398),
+    LONG_HEMIS = "W",
+    LONG_DEG = c(118L, 97L, 73L),
+    LONG_MIN = c(24L, 2L, 46L),
+    LONG_SEC = c("29.0000", "44.0000", "44.0000"),
+    LONG_DECIMAL = c(-118.4081, -97.0456, -73.7789),
+    ELEV = c(128, 607, 13),
+    MAG_VARN = c(13.0, 4.0, -13.0),
+    MAG_VARN_HEMIS = c("E", "E", "W"),
+    MAG_VARN_YEAR = 2020L,
+    ALT_CODE = "LOW"
+  )
+  write.csv(nav_data, file.path(nav_dir, "NAV_BASE.csv"), row.names = FALSE)
 
- temp_dir
+  temp_dir
 }

--- a/tests/testthat/test-clean_data.R
+++ b/tests/testthat/test-clean_data.R
@@ -15,12 +15,13 @@ test_that("clean_airports retains 4-char ARPT_IDs and all site types", {
   temp_dir <- withr::local_tempdir()
   temp_file <- file.path(temp_dir, "APT_BASE.csv")
 
-  test_data <- data.frame(stringsAsFactors = FALSE,
+  test_data <- data.frame(
+    stringsAsFactors = FALSE,
     EFF_DATE = "12/19/2024",
     SITE_NO = c("00001", "00002", "00003"),
     SITE_TYPE_CODE = c("A", "H", "A"),
     STATE_CODE = c("CA", "AL", "AL"),
-    ARPT_ID = c("LAX", "0AL1", "AL10"),  # 4-char private LID AL10 retained
+    ARPT_ID = c("LAX", "0AL1", "AL10"), # 4-char private LID AL10 retained
     CITY = c("Los Angeles", "Helitown", "Gurley"),
     COUNTRY_CODE = "US",
     STATE_NAME = c("California", "Alabama", "Alabama"),
@@ -42,15 +43,16 @@ test_that("clean_airports retains 4-char ARPT_IDs and all site types", {
 
   result <- clean_airports(temp_file)
 
-  expect_true("AL10" %in% result$ARPT_ID)   # 4-char private LID retained
-  expect_true("0AL1" %in% result$ARPT_ID)   # heliport retained
-  expect_equal(nrow(result), 3)             # no rows dropped
+  expect_true("AL10" %in% result$ARPT_ID) # 4-char private LID retained
+  expect_true("0AL1" %in% result$ARPT_ID) # heliport retained
+  expect_equal(nrow(result), 3) # no rows dropped
 })
 
 test_that("clean_airports maps PU/PR to public/private", {
   temp_dir <- withr::local_tempdir()
   temp_file <- file.path(temp_dir, "APT_BASE.csv")
-  test_data <- data.frame(stringsAsFactors = FALSE,
+  test_data <- data.frame(
+    stringsAsFactors = FALSE,
     EFF_DATE = "12/19/2024", SITE_NO = c("00001", "00002"),
     SITE_TYPE_CODE = "A", STATE_CODE = c("CA", "AL"),
     ARPT_ID = c("LAX", "AL10"), CITY = c("Los Angeles", "Gurley"),
@@ -78,7 +80,8 @@ test_that("clean_airports maps PU/PR to public/private", {
 test_that("clean_airports output has facility_use, not facility_use_code", {
   temp_dir <- withr::local_tempdir()
   temp_file <- file.path(temp_dir, "APT_BASE.csv")
-  test_data <- data.frame(stringsAsFactors = FALSE,
+  test_data <- data.frame(
+    stringsAsFactors = FALSE,
     EFF_DATE = "12/19/2024", SITE_NO = "00001", SITE_TYPE_CODE = "A",
     STATE_CODE = "CA", ARPT_ID = "LAX", CITY = "Los Angeles",
     COUNTRY_CODE = "US", STATE_NAME = "California", COUNTY_NAME = "LA",
@@ -103,7 +106,8 @@ test_that("clean_airports output has facility_use, not facility_use_code", {
 test_that("clean_airports aborts on unknown facility-use code", {
   temp_dir <- withr::local_tempdir()
   temp_file <- file.path(temp_dir, "APT_BASE.csv")
-  test_data <- data.frame(stringsAsFactors = FALSE,
+  test_data <- data.frame(
+    stringsAsFactors = FALSE,
     EFF_DATE = "12/19/2024", SITE_NO = "00001", SITE_TYPE_CODE = "A",
     STATE_CODE = "CA", ARPT_ID = "LAX", CITY = "Los Angeles",
     COUNTRY_CODE = "US", STATE_NAME = "California", COUNTY_NAME = "LA",
@@ -114,7 +118,7 @@ test_that("clean_airports aborts on unknown facility-use code", {
     LONG_DECIMAL = -118.41,
     ELEV = 128, ELEV_METHOD_CODE = "S",
     MAG_VARN = 13.0, MAG_HEMIS = "E", MAG_VARN_YEAR = 2020L,
-    ICAO_ID = "KLAX", FACILITY_USE_CODE = "ZZ"  # invalid code
+    ICAO_ID = "KLAX", FACILITY_USE_CODE = "ZZ" # invalid code
   )
   write.csv(test_data, temp_file, row.names = FALSE)
 
@@ -129,7 +133,8 @@ test_that("clean_airports returns expected columns", {
   temp_file <- file.path(temp_dir, "APT_BASE.csv")
 
   # Create minimal valid test data
-  test_data <- data.frame(stringsAsFactors = FALSE,
+  test_data <- data.frame(
+    stringsAsFactors = FALSE,
     EFF_DATE = "12/19/2024",
     SITE_NO = "00001",
     SITE_TYPE_CODE = "A",
@@ -149,7 +154,7 @@ test_that("clean_airports returns expected columns", {
     MAG_VARN = 13.0, MAG_HEMIS = "E", MAG_VARN_YEAR = 2020L,
     ICAO_ID = "KLAX",
     FACILITY_USE_CODE = "PU",
-    EXTRA_COL = "should be dropped"  # Extra column not in schema
+    EXTRA_COL = "should be dropped" # Extra column not in schema
   )
 
   write.csv(test_data, temp_file, row.names = FALSE)
@@ -168,7 +173,8 @@ test_that("clean_airports aborts on missing columns", {
   temp_file <- file.path(temp_dir, "APT_BASE.csv")
 
   # Create data missing required columns
-  test_data <- data.frame(stringsAsFactors = FALSE,
+  test_data <- data.frame(
+    stringsAsFactors = FALSE,
     EFF_DATE = "12/19/2024",
     ARPT_ID = "LAX"
     # Missing many required columns
@@ -194,7 +200,8 @@ test_that("clean_navaids returns expected columns", {
   temp_file <- file.path(temp_dir, "NAV_BASE.csv")
 
   # Create minimal valid test data
-  test_data <- data.frame(stringsAsFactors = FALSE,
+  test_data <- data.frame(
+    stringsAsFactors = FALSE,
     EFF_DATE = "12/19/2024",
     NAV_ID = "LAX",
     NAV_TYPE = "VOR",
@@ -235,7 +242,7 @@ test_that("validate_cleaned_data accepts 4-char ARPT_IDs", {
   data <- sample_airports(3)
   names(data) <- toupper(names(data))
   names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
-  data$ARPT_ID <- c("LAX", "AL10", "0AL1")  # mixed 3/4-char now valid
+  data$ARPT_ID <- c("LAX", "AL10", "0AL1") # mixed 3/4-char now valid
 
   result <- withCallingHandlers(
     validate_cleaned_data(data, "airports"),
@@ -250,7 +257,7 @@ test_that("validate_cleaned_data aborts when facility_use column is missing", {
   data <- sample_airports(3)
   names(data) <- toupper(names(data))
   names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
-  data$facility_use <- NULL  # remove the column entirely
+  data$facility_use <- NULL # remove the column entirely
 
   expect_error(
     withCallingHandlers(
@@ -280,14 +287,14 @@ test_that("validate_cleaned_data warns but does not drop out-of-range coords", {
   data <- sample_airports(2)
   names(data) <- toupper(names(data))
   names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
-  data$LAT_DECIMAL <- c(13.4, 33.94)     # Guam-like latitude (< 18) included
-  data$LONG_DECIMAL <- c(144.8, -118.4)  # Guam-like longitude (> -64) included
+  data$LAT_DECIMAL <- c(13.4, 33.94) # Guam-like latitude (< 18) included
+  data$LONG_DECIMAL <- c(144.8, -118.4) # Guam-like longitude (> -64) included
 
   result <- withCallingHandlers(
     validate_cleaned_data(data, "airports"),
     validation_warning = function(w) invokeRestart("muffleWarning")
   )
-  expect_equal(nrow(result), 2)  # nothing filtered
+  expect_equal(nrow(result), 2) # nothing filtered
 })
 
 test_that("find_raw_data_dirs validates directory exists", {

--- a/tests/testthat/test-push_to_supabase.R
+++ b/tests/testthat/test-push_to_supabase.R
@@ -95,7 +95,8 @@ test_that("get_supabase_config aborts when SUPABASE_API_KEY is missing", {
 
 test_that("NA values are converted to NULL in JSON", {
   # This tests the convert_na_to_null helper function
-  data_with_na <- data.frame(stringsAsFactors = FALSE,
+  data_with_na <- data.frame(
+    stringsAsFactors = FALSE,
     name = c("Test", NA, "Another"),
     value = c(1, 2, NA)
   )
@@ -138,8 +139,8 @@ test_that("push_to_supabase makes correct POST request", {
   source_project_file("push_to_supabase.R")
 
   withr::local_envvar(
-    SUPABASE_API_KEY = MOCK_SUPABASE_API_KEY,
-    SUPABASE_URL = MOCK_SUPABASE_URL
+    SUPABASE_API_KEY = mock_supabase_api_key,
+    SUPABASE_URL = mock_supabase_url
   )
 
   data <- sample_airports(2)
@@ -148,7 +149,7 @@ test_that("push_to_supabase makes correct POST request", {
   httptest2::without_internet({
     httptest2::expect_POST(
       push_to_supabase("airports", data),
-      url = paste0(MOCK_SUPABASE_URL, "/rest/v1/airports")
+      url = paste0(mock_supabase_url, "/rest/v1/airports")
     )
   })
 })
@@ -158,8 +159,8 @@ test_that("push_to_supabase sends JSON body with data", {
   source_project_file("push_to_supabase.R")
 
   withr::local_envvar(
-    SUPABASE_API_KEY = MOCK_SUPABASE_API_KEY,
-    SUPABASE_URL = MOCK_SUPABASE_URL
+    SUPABASE_API_KEY = mock_supabase_api_key,
+    SUPABASE_URL = mock_supabase_url
   )
 
   data <- sample_airports(1)
@@ -179,14 +180,14 @@ test_that("clear_table makes correct DELETE request", {
   source_project_file("push_to_supabase.R")
 
   withr::local_envvar(
-    SUPABASE_API_KEY = MOCK_SUPABASE_API_KEY,
-    SUPABASE_URL = MOCK_SUPABASE_URL
+    SUPABASE_API_KEY = mock_supabase_api_key,
+    SUPABASE_URL = mock_supabase_url
   )
 
   httptest2::without_internet({
     httptest2::expect_DELETE(
       clear_table("airports"),
-      url = paste0(MOCK_SUPABASE_URL, "/rest/v1/airports")
+      url = paste0(mock_supabase_url, "/rest/v1/airports")
     )
   })
 })
@@ -196,15 +197,15 @@ test_that("clear_table targets correct table in URL", {
   source_project_file("push_to_supabase.R")
 
   withr::local_envvar(
-    SUPABASE_API_KEY = MOCK_SUPABASE_API_KEY,
-    SUPABASE_URL = MOCK_SUPABASE_URL
+    SUPABASE_API_KEY = mock_supabase_api_key,
+    SUPABASE_URL = mock_supabase_url
   )
 
   # Verify table name appears in URL for navaids table
   httptest2::without_internet({
     httptest2::expect_DELETE(
       clear_table("navaids"),
-      url = paste0(MOCK_SUPABASE_URL, "/rest/v1/navaids")
+      url = paste0(mock_supabase_url, "/rest/v1/navaids")
     )
   })
 })
@@ -214,8 +215,8 @@ test_that("push_to_supabase body includes facility_use", {
   source_project_file("push_to_supabase.R")
 
   withr::local_envvar(
-    SUPABASE_API_KEY = MOCK_SUPABASE_API_KEY,
-    SUPABASE_URL = MOCK_SUPABASE_URL
+    SUPABASE_API_KEY = mock_supabase_api_key,
+    SUPABASE_URL = mock_supabase_url
   )
 
   data <- sample_airports(1)

--- a/tests/testthat/test-scrape_airports_navaids.R
+++ b/tests/testthat/test-scrape_airports_navaids.R
@@ -69,7 +69,7 @@ test_that("scrape_faa_current_date returns a Date", {
   expect_s3_class(result, "Date")
   # Date should be reasonable (within last year)
   expect_true(result > Sys.Date() - 365)
-  expect_true(result <= Sys.Date() + 30)  # Allow for future effective dates
+  expect_true(result <= Sys.Date() + 30) # Allow for future effective dates
 })
 
 test_that("download_faa_data validates date argument", {

--- a/tests/testthat/test-update_readme.R
+++ b/tests/testthat/test-update_readme.R
@@ -42,7 +42,8 @@ test_that("update_readme validates count arguments", {
 test_that("update_readme validates readme_path exists", {
   expect_error(
     update_readme(Sys.Date(), 5000, 1500,
-                  readme_path = "/nonexistent/README.md")
+      readme_path = "/nonexistent/README.md"
+    )
   )
 })
 


### PR DESCRIPTION
Part 1 of #16 (item 3 and the lint-scope decision).

- Fixes the 19 pre-existing lints in tests/ (17 indentation via styler, 2 object_name via mock constant rename).
- Adds .github/workflows/ci.yml running lintr (R/ + tests/) and testthat on pull_request and push to main.
- lintr is version-pinned in the workflow (3.3.0.1) rather than added to renv.lock: snapshotting from local R 4.6.1 would rewrite the lockfile R version field that the daily pipeline restores against.
- Post-review hardening: lint results are printed as classed lints objects so GitHub inline PR annotations work; job has timeout-minutes: 30.
- Enforcement note: this PR makes the gates RUN on every PR; it does not make them REQUIRED. A branch ruleset requiring lint-test is deliberately deferred: the daily pipeline pushes directly to main, and a naive required-check rule would reject those bot pushes. Enforcing later needs a bypass actor for the github-actions app (follow-up decision).

Generated with [Claude Code](https://claude.com/claude-code)