### PR TITLE
refactor: split clean_data.R, fail-fast validation, dead-code cleanup

### DIFF
--- a/.Renviron.example
+++ b/.Renviron.example
@@ -3,22 +3,3 @@
 # Get from: Supabase Dashboard > Settings > API > Secret keys
 # Format: sb_secret_... (new format) or eyJ... (legacy JWT, deprecated end of 2026)
 SUPABASE_API_KEY=sb_secret_your_key_here
-
-# Notification Settings
-# Set to "true" or "false" to enable/disable each channel
-NOTIFY_EMAIL_ENABLED=false
-NOTIFY_SMS_ENABLED=false
-
-# Contact Information
-NOTIFY_EMAIL=your_email@example.com
-NOTIFY_PHONE=+15551234567
-
-# Twilio Credentials (for SMS)
-# Get these from https://console.twilio.com/
-TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-TWILIO_AUTH_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-TWILIO_FROM_NUMBER=+15559876543
-
-# SendGrid Credentials (for Email)
-# Access via Twilio Console > Email > SendGrid
-SENDGRID_API_KEY=SG.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,9 @@ Rscript -e "testthat::test_dir('tests/testthat')"
 # Run a single test file
 Rscript -e "testthat::test_file('tests/testthat/test-clean_data.R')"
 
-# Lint R files
+# Lint R files and tests
 Rscript -e "lintr::lint_dir('R')"
+Rscript -e "lintr::lint_dir('tests')"
 
 # Lint a single file
 Rscript -e "lintr::lint('R/clean_data.R')"
@@ -64,7 +65,7 @@ All enforced gates must pass before merge.
 | Gate | Tool | Fails When |
 |------|------|------------|
 | Line length | `.lintr` (lintr) | Any line exceeds 110 characters |
-| Lint check | `lintr::lint_dir('R')` | lintr reports any issues |
+| Lint check | `lintr::lint_dir('R')` + `lintr::lint_dir('tests')` | lintr reports any issues |
 | Test suite | `testthat::test_dir()` | Any testthat test fails |
 
 ### Policy Gates (Code Review)
@@ -126,7 +127,8 @@ data: update to December 2025 FAA subscription
 airports-navaids/
 |-- R/
 |   |-- scrape_airports_navaids.R  # Main orchestrator
-|   |-- clean_data.R               # Data transformation
+|   |-- clean_airports.R           # Airport cleaning and validation
+|   |-- clean_data.R               # Navaid cleaning; shared orchestration
 |   |-- push_to_supabase.R         # Database upload
 |-- sql/
 |   |-- create_tables.sql          # PostgreSQL schema

--- a/R/clean_airports.R
+++ b/R/clean_airports.R
@@ -1,0 +1,168 @@
+# clean_airports.R
+# Functions for cleaning FAA airport data (APT_BASE.csv)
+#
+# Companion to clean_data.R, which holds navaids cleaning, shared
+# orchestration helpers, and the validate_cleaned_data() dispatcher that
+# delegates airports validation to validate_airports() defined here.
+# Consumers of the airports path must source both files.
+#
+# Usage:
+#   source("R/clean_airports.R")
+#   airports <- clean_airports("data/raw/19_DEC_2024_APT_CSV/APT_BASE.csv")
+
+library(checkmate)
+library(rlang)
+
+# --- Schema Definitions ---
+#
+# Airports: ALL NASR landing facilities are admitted (no row filtering).
+# Site type is carried via SITE_TYPE_CODE; facility use via facility_use.
+#   - FACILITY_USE_CODE (PU/PR) is read as the mapping source for facility_use
+#     and is NOT retained in the output.
+#   - Row count: warn if < 18000
+#   - LAT_DECIMAL / LONG_DECIMAL out-of-US-bounds: warn only, never filter
+#
+# Raw FAA source columns required to exist in APT_BASE.csv:
+airports_source_columns <- c(
+  "EFF_DATE", "SITE_NO", "SITE_TYPE_CODE", "STATE_CODE", "ARPT_ID",
+  "CITY", "COUNTRY_CODE", "STATE_NAME", "COUNTY_NAME", "ARPT_NAME",
+  "LAT_DEG", "LAT_MIN", "LAT_SEC", "LAT_HEMIS", "LAT_DECIMAL",
+  "LONG_DEG", "LONG_MIN", "LONG_SEC", "LONG_HEMIS", "LONG_DECIMAL",
+  "ELEV", "ELEV_METHOD_CODE", "MAG_VARN", "MAG_HEMIS", "MAG_VARN_YEAR",
+  "ICAO_ID", "FACILITY_USE_CODE"
+)
+
+# Output columns: raw FACILITY_USE_CODE is dropped, derived facility_use added.
+airports_columns <- c(
+  "EFF_DATE", "SITE_NO", "SITE_TYPE_CODE", "STATE_CODE", "ARPT_ID",
+  "CITY", "COUNTRY_CODE", "STATE_NAME", "COUNTY_NAME", "ARPT_NAME",
+  "LAT_DEG", "LAT_MIN", "LAT_SEC", "LAT_HEMIS", "LAT_DECIMAL",
+  "LONG_DEG", "LONG_MIN", "LONG_SEC", "LONG_HEMIS", "LONG_DECIMAL",
+  "ELEV", "ELEV_METHOD_CODE", "MAG_VARN", "MAG_HEMIS", "MAG_VARN_YEAR",
+  "ICAO_ID", "facility_use"
+)
+
+#' Map FAA FACILITY_USE_CODE to a friendly label
+#'
+#' @param codes Character vector of FAA facility-use codes (PU/PR)
+#' @return Character vector of "public"/"private"; aborts on any other value
+#' @keywords internal
+map_facility_use <- function(codes) {
+  mapping <- c(PU = "public", PR = "private")
+  unknown <- setdiff(unique(codes), names(mapping))
+  if (length(unknown) > 0) {
+    rlang::abort(
+      c(
+        "Unexpected FACILITY_USE_CODE value(s)",
+        x = paste("Unknown:", paste(unknown, collapse = ", ")),
+        i = "Expected only PU or PR"
+      ),
+      class = "clean_data_facility_use_error"
+    )
+  }
+  unname(mapping[codes])
+}
+
+#' Clean airport data from FAA APT_BASE.csv
+#'
+#' Reads APT_BASE.csv, admits all NASR landing facilities (no row filtering),
+#' maps FACILITY_USE_CODE to facility_use, and selects relevant columns.
+#'
+#' @param apt_base_path Path to APT_BASE.csv file
+#' @return Data frame with cleaned airport data
+#' @export
+clean_airports <- function(apt_base_path) {
+  # --- Input validation ---
+  checkmate::assert_file_exists(apt_base_path, extension = "csv")
+
+  message("Reading airports from: ", apt_base_path)
+
+  # FAA files use ISO-8859-1 (Latin-1) encoding for special characters
+  airports_raw <- read.csv(
+    apt_base_path,
+    fileEncoding = "ISO-8859-1",
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )
+
+  # Verify required source columns exist
+  missing_cols <- setdiff(airports_source_columns, names(airports_raw))
+  if (length(missing_cols) > 0) {
+    rlang::abort(
+      c(
+        "APT_BASE.csv missing required columns",
+        x = paste("Missing:", paste(missing_cols, collapse = ", "))
+      ),
+      class = "clean_data_schema_error"
+    )
+  }
+
+  # Map facility-use code to friendly label (fail loud on unknown code)
+  airports_raw$facility_use <- map_facility_use(airports_raw$FACILITY_USE_CODE)
+
+  # No row filtering: admit all site types and all ID lengths
+  airports <- airports_raw[, airports_columns]
+
+  if (nrow(airports) == 0) {
+    rlang::abort(
+      "No airports found in APT_BASE.csv",
+      class = "clean_data_empty_result"
+    )
+  }
+
+  message("Cleaned ", nrow(airports), " airports")
+  airports
+}
+
+#' Validate cleaned airports data
+#'
+#' Fail-fast ordering: structural aborts first, then non-halting warnings.
+#'
+#' @param data Data frame of cleaned airports data
+#' @return The input data (invisibly) if valid, otherwise aborts
+#' @keywords internal
+validate_airports <- function(data) {
+  # facility_use column must be present (fail loud; NULL would pass vacuously)
+  if (!"facility_use" %in% names(data)) {
+    rlang::abort(
+      "Column 'facility_use' is missing from airports data",
+      class = "validation_error"
+    )
+  }
+
+  # facility_use must be one of the mapped labels (error - critical)
+  if (!all(data$facility_use %in% c("public", "private"))) {
+    rlang::abort(
+      "facility_use contains values outside {public, private}",
+      class = "validation_error"
+    )
+  }
+
+  # Check expected row count (warning only)
+  if (nrow(data) < 18000) {
+    rlang::warn(
+      paste("Expected at least 18000 airports, got", nrow(data)),
+      class = "validation_warning"
+    )
+  }
+
+  # Check latitude range (warning only - never filter; US territories)
+  lat_valid <- data$LAT_DECIMAL >= 18 & data$LAT_DECIMAL <= 72
+  if (!all(lat_valid, na.rm = TRUE)) {
+    rlang::warn(
+      "Some latitude values outside expected US range (18-72)",
+      class = "validation_warning"
+    )
+  }
+
+  # Check longitude range (warning only - never filter; US territories)
+  long_valid <- data$LONG_DECIMAL >= -180 & data$LONG_DECIMAL <= -64
+  if (!all(long_valid, na.rm = TRUE)) {
+    rlang::warn(
+      "Some longitude values outside expected US range (-180 to -64)",
+      class = "validation_warning"
+    )
+  }
+
+  invisible(data)
+}

--- a/R/clean_data.R
+++ b/R/clean_data.R
@@ -1,12 +1,16 @@
 # clean_data.R
-# Functions for cleaning FAA airport and navaid data
+# Functions for cleaning FAA navaid data plus shared cleaning orchestration
+#
+# Airports-specific cleaning lives in clean_airports.R; the
+# validate_cleaned_data() dispatcher here delegates to validate_airports()
+# from that file, so consumers of the airports path must source both files.
 #
 # Usage:
+#   source("R/clean_airports.R")
 #   source("R/clean_data.R")
-#   airports <- clean_airports("data/raw/19_DEC_2024_APT_CSV/APT_BASE.csv")
 #   navaids <- clean_navaids("data/raw/19_DEC_2024_NAV_CSV/NAV_BASE.csv")
 #
-# Or run directly to clean current raw data:
+# Or run directly to clean current raw data (airports and navaids):
 #   Rscript R/clean_data.R
 
 library(checkmate)
@@ -14,33 +18,6 @@ library(rlang)
 
 # --- Schema Definitions ---
 #
-# Airports: ALL NASR landing facilities are admitted (no row filtering).
-# Site type is carried via SITE_TYPE_CODE; facility use via facility_use.
-#   - FACILITY_USE_CODE (PU/PR) is read as the mapping source for facility_use
-#     and is NOT retained in the output.
-#   - Row count: warn if < 18000
-#   - LAT_DECIMAL / LONG_DECIMAL out-of-US-bounds: warn only, never filter
-#
-# Raw FAA source columns required to exist in APT_BASE.csv:
-airports_source_columns <- c(
-  "EFF_DATE", "SITE_NO", "SITE_TYPE_CODE", "STATE_CODE", "ARPT_ID",
-  "CITY", "COUNTRY_CODE", "STATE_NAME", "COUNTY_NAME", "ARPT_NAME",
-  "LAT_DEG", "LAT_MIN", "LAT_SEC", "LAT_HEMIS", "LAT_DECIMAL",
-  "LONG_DEG", "LONG_MIN", "LONG_SEC", "LONG_HEMIS", "LONG_DECIMAL",
-  "ELEV", "ELEV_METHOD_CODE", "MAG_VARN", "MAG_HEMIS", "MAG_VARN_YEAR",
-  "ICAO_ID", "FACILITY_USE_CODE"
-)
-
-# Output columns: raw FACILITY_USE_CODE is dropped, derived facility_use added.
-airports_columns <- c(
-  "EFF_DATE", "SITE_NO", "SITE_TYPE_CODE", "STATE_CODE", "ARPT_ID",
-  "CITY", "COUNTRY_CODE", "STATE_NAME", "COUNTY_NAME", "ARPT_NAME",
-  "LAT_DEG", "LAT_MIN", "LAT_SEC", "LAT_HEMIS", "LAT_DECIMAL",
-  "LONG_DEG", "LONG_MIN", "LONG_SEC", "LONG_HEMIS", "LONG_DECIMAL",
-  "ELEV", "ELEV_METHOD_CODE", "MAG_VARN", "MAG_HEMIS", "MAG_VARN_YEAR",
-  "ICAO_ID", "facility_use"
-)
-
 # Navaids validation rules:
 #   - Row count: warn if < 1000
 #   - NAV_TYPE: warn if not in valid_nav_types
@@ -58,78 +35,6 @@ valid_nav_types <- c(
   "CONSOLAN", "DME", "FAN MARKER", "MARINE NDB", "MARINE NDB/DME",
   "NDB", "NDB/DME", "TACAN", "UHF/NDB", "VOR", "VOR/DME", "VORTAC", "VOT"
 )
-
-#' Map FAA FACILITY_USE_CODE to a friendly label
-#'
-#' @param codes Character vector of FAA facility-use codes (PU/PR)
-#' @return Character vector of "public"/"private"; aborts on any other value
-#' @keywords internal
-map_facility_use <- function(codes) {
-  mapping <- c(PU = "public", PR = "private")
-  unknown <- setdiff(unique(codes), names(mapping))
-  if (length(unknown) > 0) {
-    rlang::abort(
-      c(
-        "Unexpected FACILITY_USE_CODE value(s)",
-        x = paste("Unknown:", paste(unknown, collapse = ", ")),
-        i = "Expected only PU or PR"
-      ),
-      class = "clean_data_facility_use_error"
-    )
-  }
-  unname(mapping[codes])
-}
-
-#' Clean airport data from FAA APT_BASE.csv
-#'
-#' Reads APT_BASE.csv, admits all NASR landing facilities (no row filtering),
-#' maps FACILITY_USE_CODE to facility_use, and selects relevant columns.
-#'
-#' @param apt_base_path Path to APT_BASE.csv file
-#' @return Data frame with cleaned airport data
-#' @export
-clean_airports <- function(apt_base_path) {
-  # --- Input validation ---
-  checkmate::assert_file_exists(apt_base_path, extension = "csv")
-
-  message("Reading airports from: ", apt_base_path)
-
-  # FAA files use ISO-8859-1 (Latin-1) encoding for special characters
-  airports_raw <- read.csv(
-    apt_base_path,
-    fileEncoding = "ISO-8859-1",
-    stringsAsFactors = FALSE,
-    check.names = FALSE
-  )
-
-  # Verify required source columns exist
-  missing_cols <- setdiff(airports_source_columns, names(airports_raw))
-  if (length(missing_cols) > 0) {
-    rlang::abort(
-      c(
-        "APT_BASE.csv missing required columns",
-        x = paste("Missing:", paste(missing_cols, collapse = ", "))
-      ),
-      class = "clean_data_schema_error"
-    )
-  }
-
-  # Map facility-use code to friendly label (fail loud on unknown code)
-  airports_raw$facility_use <- map_facility_use(airports_raw$FACILITY_USE_CODE)
-
-  # No row filtering: admit all site types and all ID lengths
-  airports <- airports_raw[, airports_columns]
-
-  if (nrow(airports) == 0) {
-    rlang::abort(
-      "No airports found in APT_BASE.csv",
-      class = "clean_data_empty_result"
-    )
-  }
-
-  message("Cleaned ", nrow(airports), " airports")
-  airports
-}
 
 #' Clean navaid data from FAA NAV_BASE.csv
 #'
@@ -178,9 +83,41 @@ clean_navaids <- function(nav_base_path) {
   navaids
 }
 
+#' Validate cleaned navaids data
+#'
+#' All navaids checks are non-halting warnings.
+#'
+#' @param data Data frame of cleaned navaids data
+#' @return The input data (invisibly)
+#' @keywords internal
+validate_navaids <- function(data) {
+  # Check expected row count (warning only)
+  if (nrow(data) < 1000) {
+    rlang::warn(
+      paste("Expected at least 1000 navaids, got", nrow(data)),
+      class = "validation_warning"
+    )
+  }
+
+  # Check NAV_TYPE values (warning only)
+  invalid_types <- setdiff(unique(data$NAV_TYPE), valid_nav_types)
+  if (length(invalid_types) > 0) {
+    rlang::warn(
+      c(
+        "Unexpected NAV_TYPE values found",
+        i = paste("Unknown types:", paste(invalid_types, collapse = ", "))
+      ),
+      class = "validation_warning"
+    )
+  }
+
+  invisible(data)
+}
+
 #' Validate cleaned data against schema rules
 #'
-#' Performs data quality checks on cleaned airports or navaids data.
+#' Dispatches to validate_airports() (clean_airports.R) or
+#' validate_navaids() based on schema_type.
 #'
 #' @param data Tibble of cleaned data
 #' @param schema_type One of "airports" or "navaids"
@@ -194,68 +131,9 @@ validate_cleaned_data <- function(data,
   message("Validating ", schema_type, " data...")
 
   if (schema_type == "airports") {
-    # Check expected row count (warning only)
-    if (nrow(data) < 18000) {
-      rlang::warn(
-        paste("Expected at least 18000 airports, got", nrow(data)),
-        class = "validation_warning"
-      )
-    }
-
-    # facility_use column must be present (fail loud; NULL would pass vacuously)
-    if (!"facility_use" %in% names(data)) {
-      rlang::abort(
-        "Column 'facility_use' is missing from airports data",
-        class = "validation_error"
-      )
-    }
-
-    # facility_use must be one of the mapped labels (error - critical)
-    if (!all(data$facility_use %in% c("public", "private"))) {
-      rlang::abort(
-        "facility_use contains values outside {public, private}",
-        class = "validation_error"
-      )
-    }
-
-    # Check latitude range (warning only - never filter; US territories)
-    lat_valid <- data$LAT_DECIMAL >= 18 & data$LAT_DECIMAL <= 72
-    if (!all(lat_valid, na.rm = TRUE)) {
-      rlang::warn(
-        "Some latitude values outside expected US range (18-72)",
-        class = "validation_warning"
-      )
-    }
-
-    # Check longitude range (warning only - never filter; US territories)
-    long_valid <- data$LONG_DECIMAL >= -180 & data$LONG_DECIMAL <= -64
-    if (!all(long_valid, na.rm = TRUE)) {
-      rlang::warn(
-        "Some longitude values outside expected US range (-180 to -64)",
-        class = "validation_warning"
-      )
-    }
+    validate_airports(data)
   } else {
-    # Navaid-specific validation
-    # Check expected row count (warning only)
-    if (nrow(data) < 1000) {
-      rlang::warn(
-        paste("Expected at least 1000 navaids, got", nrow(data)),
-        class = "validation_warning"
-      )
-    }
-
-    # Check NAV_TYPE values (warning only)
-    invalid_types <- setdiff(unique(data$NAV_TYPE), valid_nav_types)
-    if (length(invalid_types) > 0) {
-      rlang::warn(
-        c(
-          "Unexpected NAV_TYPE values found",
-          i = paste("Unknown types:", paste(invalid_types, collapse = ", "))
-        ),
-        class = "validation_warning"
-      )
-    }
+    validate_navaids(data)
   }
 
   message("Validation complete for ", schema_type)
@@ -321,6 +199,8 @@ remove_extra_files <- function(apt_dir, nav_dir) {
 
 # --- Main execution (only when run directly) ---
 if (sys.nframe() == 0L) {
+  source("R/clean_airports.R")
+
   message("Running clean_data.R as main script...")
 
   # Find raw data directories

--- a/R/scrape_airports_navaids.R
+++ b/R/scrape_airports_navaids.R
@@ -270,6 +270,7 @@ run_pipeline <- function(force = FALSE) {
   nav_dir <- download_faa_data(current_date, "NAV", "data/raw")
 
   # Source the cleaning and push scripts (functions only, no execution)
+  source("R/clean_airports.R", local = FALSE)
   source("R/clean_data.R", local = FALSE)
   source("R/push_to_supabase.R", local = FALSE)
   source("R/update_readme.R", local = FALSE)

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ This project uses Supabase Row Level Security (RLS) with the new API key format:
 airports-navaids/
 ├── R/
 │   ├── scrape_airports_navaids.R  # Main pipeline - orchestrates everything
-│   ├── clean_data.R               # Filters and cleans raw FAA CSV data
+│   ├── clean_airports.R           # Cleans and validates FAA airport data
+│   ├── clean_data.R               # Cleans navaids; shared cleaning orchestration
 │   ├── push_to_supabase.R         # Pushes to Supabase via REST API
 │   └── update_readme.R            # Updates README with pipeline results
 ├── sql/

--- a/tests/testthat/test-clean_airports.R
+++ b/tests/testthat/test-clean_airports.R
@@ -1,0 +1,270 @@
+# test-clean_airports.R
+# Tests for R/clean_airports.R functions
+
+# clean_airports.R defines the airports functions; clean_data.R defines the
+# validate_cleaned_data() dispatcher that delegates to validate_airports().
+source_project_file("clean_airports.R")
+source_project_file("clean_data.R")
+
+test_that("clean_airports validates file path exists", {
+  expect_error(
+    clean_airports("/nonexistent/path/APT_BASE.csv"),
+    class = "simpleError"
+  )
+})
+
+test_that("clean_airports retains 4-char ARPT_IDs and all site types", {
+  temp_dir <- withr::local_tempdir()
+  temp_file <- file.path(temp_dir, "APT_BASE.csv")
+
+  test_data <- data.frame(
+    stringsAsFactors = FALSE,
+    EFF_DATE = "12/19/2024",
+    SITE_NO = c("00001", "00002", "00003"),
+    SITE_TYPE_CODE = c("A", "H", "A"),
+    STATE_CODE = c("CA", "AL", "AL"),
+    ARPT_ID = c("LAX", "0AL1", "AL10"), # 4-char private LID AL10 retained
+    CITY = c("Los Angeles", "Helitown", "Gurley"),
+    COUNTRY_CODE = "US",
+    STATE_NAME = c("California", "Alabama", "Alabama"),
+    COUNTY_NAME = c("Los Angeles", "X", "Madison"),
+    ARPT_NAME = c("Los Angeles Intl", "Helipad", "Frerichs"),
+    LAT_DEG = c(33L, 34L, 34L), LAT_MIN = c(56L, 0L, 42L),
+    LAT_SEC = c("33.00", "0.00", "0.00"), LAT_HEMIS = "N",
+    LAT_DECIMAL = c(33.94, 34.0, 34.7),
+    LONG_DEG = c(118L, 86L, 86L), LONG_MIN = c(24L, 0L, 21L),
+    LONG_SEC = c("29.00", "0.00", "0.00"), LONG_HEMIS = "W",
+    LONG_DECIMAL = c(-118.41, -86.0, -86.35),
+    ELEV = c(128, 600, 700),
+    ELEV_METHOD_CODE = "S",
+    MAG_VARN = c(13.0, 2.0, 2.0), MAG_HEMIS = "W", MAG_VARN_YEAR = 2020L,
+    ICAO_ID = c("KLAX", "", ""),
+    FACILITY_USE_CODE = c("PU", "PR", "PR")
+  )
+  write.csv(test_data, temp_file, row.names = FALSE)
+
+  result <- clean_airports(temp_file)
+
+  expect_true("AL10" %in% result$ARPT_ID) # 4-char private LID retained
+  expect_true("0AL1" %in% result$ARPT_ID) # heliport retained
+  expect_equal(nrow(result), 3) # no rows dropped
+})
+
+test_that("clean_airports maps PU/PR to public/private", {
+  temp_dir <- withr::local_tempdir()
+  temp_file <- file.path(temp_dir, "APT_BASE.csv")
+  test_data <- data.frame(
+    stringsAsFactors = FALSE,
+    EFF_DATE = "12/19/2024", SITE_NO = c("00001", "00002"),
+    SITE_TYPE_CODE = "A", STATE_CODE = c("CA", "AL"),
+    ARPT_ID = c("LAX", "AL10"), CITY = c("Los Angeles", "Gurley"),
+    COUNTRY_CODE = "US", STATE_NAME = c("California", "Alabama"),
+    COUNTY_NAME = c("Los Angeles", "Madison"),
+    ARPT_NAME = c("Los Angeles Intl", "Frerichs"),
+    LAT_DEG = c(33L, 34L), LAT_MIN = c(56L, 42L),
+    LAT_SEC = c("33.00", "0.00"), LAT_HEMIS = "N",
+    LAT_DECIMAL = c(33.94, 34.7),
+    LONG_DEG = c(118L, 86L), LONG_MIN = c(24L, 21L),
+    LONG_SEC = c("29.00", "0.00"), LONG_HEMIS = "W",
+    LONG_DECIMAL = c(-118.41, -86.35),
+    ELEV = c(128, 700), ELEV_METHOD_CODE = "S",
+    MAG_VARN = c(13.0, 2.0), MAG_HEMIS = "W", MAG_VARN_YEAR = 2020L,
+    ICAO_ID = c("KLAX", ""), FACILITY_USE_CODE = c("PU", "PR")
+  )
+  write.csv(test_data, temp_file, row.names = FALSE)
+
+  result <- clean_airports(temp_file)
+
+  expect_equal(result$facility_use[result$ARPT_ID == "LAX"], "public")
+  expect_equal(result$facility_use[result$ARPT_ID == "AL10"], "private")
+})
+
+test_that("clean_airports output has facility_use, not facility_use_code", {
+  temp_dir <- withr::local_tempdir()
+  temp_file <- file.path(temp_dir, "APT_BASE.csv")
+  test_data <- data.frame(
+    stringsAsFactors = FALSE,
+    EFF_DATE = "12/19/2024", SITE_NO = "00001", SITE_TYPE_CODE = "A",
+    STATE_CODE = "CA", ARPT_ID = "LAX", CITY = "Los Angeles",
+    COUNTRY_CODE = "US", STATE_NAME = "California", COUNTY_NAME = "LA",
+    ARPT_NAME = "Los Angeles Intl",
+    LAT_DEG = 33L, LAT_MIN = 56L, LAT_SEC = "33.00", LAT_HEMIS = "N",
+    LAT_DECIMAL = 33.94,
+    LONG_DEG = 118L, LONG_MIN = 24L, LONG_SEC = "29.00", LONG_HEMIS = "W",
+    LONG_DECIMAL = -118.41,
+    ELEV = 128, ELEV_METHOD_CODE = "S",
+    MAG_VARN = 13.0, MAG_HEMIS = "E", MAG_VARN_YEAR = 2020L,
+    ICAO_ID = "KLAX", FACILITY_USE_CODE = "PU"
+  )
+  write.csv(test_data, temp_file, row.names = FALSE)
+
+  result <- clean_airports(temp_file)
+
+  expect_true("facility_use" %in% names(result))
+  expect_false("facility_use_code" %in% tolower(names(result)))
+  expect_false("FACILITY_USE_CODE" %in% names(result))
+})
+
+test_that("clean_airports aborts on unknown facility-use code", {
+  temp_dir <- withr::local_tempdir()
+  temp_file <- file.path(temp_dir, "APT_BASE.csv")
+  test_data <- data.frame(
+    stringsAsFactors = FALSE,
+    EFF_DATE = "12/19/2024", SITE_NO = "00001", SITE_TYPE_CODE = "A",
+    STATE_CODE = "CA", ARPT_ID = "LAX", CITY = "Los Angeles",
+    COUNTRY_CODE = "US", STATE_NAME = "California", COUNTY_NAME = "LA",
+    ARPT_NAME = "Los Angeles Intl",
+    LAT_DEG = 33L, LAT_MIN = 56L, LAT_SEC = "33.00", LAT_HEMIS = "N",
+    LAT_DECIMAL = 33.94,
+    LONG_DEG = 118L, LONG_MIN = 24L, LONG_SEC = "29.00", LONG_HEMIS = "W",
+    LONG_DECIMAL = -118.41,
+    ELEV = 128, ELEV_METHOD_CODE = "S",
+    MAG_VARN = 13.0, MAG_HEMIS = "E", MAG_VARN_YEAR = 2020L,
+    ICAO_ID = "KLAX", FACILITY_USE_CODE = "ZZ" # invalid code
+  )
+  write.csv(test_data, temp_file, row.names = FALSE)
+
+  expect_error(
+    clean_airports(temp_file),
+    class = "clean_data_facility_use_error"
+  )
+})
+
+test_that("clean_airports returns expected columns", {
+  temp_dir <- withr::local_tempdir()
+  temp_file <- file.path(temp_dir, "APT_BASE.csv")
+
+  # Create minimal valid test data
+  test_data <- data.frame(
+    stringsAsFactors = FALSE,
+    EFF_DATE = "12/19/2024",
+    SITE_NO = "00001",
+    SITE_TYPE_CODE = "A",
+    STATE_CODE = "CA",
+    ARPT_ID = "LAX",
+    CITY = "Los Angeles",
+    COUNTRY_CODE = "US",
+    STATE_NAME = "California",
+    COUNTY_NAME = "Los Angeles",
+    ARPT_NAME = "Los Angeles Intl",
+    LAT_DEG = 33L, LAT_MIN = 56L, LAT_SEC = "33.00", LAT_HEMIS = "N",
+    LAT_DECIMAL = 33.94,
+    LONG_DEG = 118L, LONG_MIN = 24L, LONG_SEC = "29.00", LONG_HEMIS = "W",
+    LONG_DECIMAL = -118.41,
+    ELEV = 128,
+    ELEV_METHOD_CODE = "S",
+    MAG_VARN = 13.0, MAG_HEMIS = "E", MAG_VARN_YEAR = 2020L,
+    ICAO_ID = "KLAX",
+    FACILITY_USE_CODE = "PU",
+    EXTRA_COL = "should be dropped" # Extra column not in schema
+  )
+
+  write.csv(test_data, temp_file, row.names = FALSE)
+
+  result <- clean_airports(temp_file)
+
+  # Should have exactly the expected columns
+  expect_equal(sort(names(result)), sort(airports_columns))
+
+  # Extra column should be dropped
+  expect_false("EXTRA_COL" %in% names(result))
+})
+
+test_that("clean_airports aborts on missing columns", {
+  temp_dir <- withr::local_tempdir()
+  temp_file <- file.path(temp_dir, "APT_BASE.csv")
+
+  # Create data missing required columns
+  test_data <- data.frame(
+    stringsAsFactors = FALSE,
+    EFF_DATE = "12/19/2024",
+    ARPT_ID = "LAX"
+    # Missing many required columns
+  )
+
+  write.csv(test_data, temp_file, row.names = FALSE)
+
+  expect_error(
+    clean_airports(temp_file),
+    class = "clean_data_schema_error"
+  )
+})
+
+test_that("validate_cleaned_data accepts 4-char ARPT_IDs", {
+  data <- sample_airports(3)
+  names(data) <- toupper(names(data))
+  names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
+  data$ARPT_ID <- c("LAX", "AL10", "0AL1") # mixed 3/4-char now valid
+
+  result <- withCallingHandlers(
+    validate_cleaned_data(data, "airports"),
+    validation_warning = function(w) invokeRestart("muffleWarning")
+  )
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 3)
+  expect_true(all(c("AL10", "0AL1") %in% result$ARPT_ID))
+})
+
+test_that("validate_cleaned_data aborts when facility_use column is missing", {
+  data <- sample_airports(3)
+  names(data) <- toupper(names(data))
+  names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
+  data$facility_use <- NULL # remove the column entirely
+
+  expect_error(
+    withCallingHandlers(
+      validate_cleaned_data(data, "airports"),
+      validation_warning = function(w) invokeRestart("muffleWarning")
+    ),
+    class = "validation_error"
+  )
+})
+
+test_that("validate_cleaned_data aborts on invalid facility_use", {
+  data <- sample_airports(3)
+  names(data) <- toupper(names(data))
+  names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
+  data$facility_use <- c("public", "private", "bogus")
+
+  expect_error(
+    withCallingHandlers(
+      validate_cleaned_data(data, "airports"),
+      validation_warning = function(w) invokeRestart("muffleWarning")
+    ),
+    class = "validation_error"
+  )
+})
+
+test_that("validate_cleaned_data warns but does not drop out-of-range coords", {
+  data <- sample_airports(2)
+  names(data) <- toupper(names(data))
+  names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
+  data$LAT_DECIMAL <- c(13.4, 33.94) # Guam-like latitude (< 18) included
+  data$LONG_DECIMAL <- c(144.8, -118.4) # Guam-like longitude (> -64) included
+
+  result <- withCallingHandlers(
+    validate_cleaned_data(data, "airports"),
+    validation_warning = function(w) invokeRestart("muffleWarning")
+  )
+  expect_equal(nrow(result), 2) # nothing filtered
+})
+
+test_that("airports validation aborts before any warning fires", {
+  data <- sample_airports(3) # 3 rows: under-count would warn
+  names(data) <- toupper(names(data))
+  names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
+  data$facility_use <- NULL # structural failure: column missing
+
+  warnings_seen <- character()
+  expect_error(
+    withCallingHandlers(
+      validate_cleaned_data(data, "airports"),
+      validation_warning = function(w) {
+        warnings_seen <<- c(warnings_seen, conditionMessage(w))
+        invokeRestart("muffleWarning")
+      }
+    ),
+    class = "validation_error"
+  )
+  expect_length(warnings_seen, 0)
+})

--- a/tests/testthat/test-clean_data.R
+++ b/tests/testthat/test-clean_data.R
@@ -4,190 +4,6 @@
 # Source the refactored functions
 source_project_file("clean_data.R")
 
-test_that("clean_airports validates file path exists", {
-  expect_error(
-    clean_airports("/nonexistent/path/APT_BASE.csv"),
-    class = "simpleError"
-  )
-})
-
-test_that("clean_airports retains 4-char ARPT_IDs and all site types", {
-  temp_dir <- withr::local_tempdir()
-  temp_file <- file.path(temp_dir, "APT_BASE.csv")
-
-  test_data <- data.frame(
-    stringsAsFactors = FALSE,
-    EFF_DATE = "12/19/2024",
-    SITE_NO = c("00001", "00002", "00003"),
-    SITE_TYPE_CODE = c("A", "H", "A"),
-    STATE_CODE = c("CA", "AL", "AL"),
-    ARPT_ID = c("LAX", "0AL1", "AL10"), # 4-char private LID AL10 retained
-    CITY = c("Los Angeles", "Helitown", "Gurley"),
-    COUNTRY_CODE = "US",
-    STATE_NAME = c("California", "Alabama", "Alabama"),
-    COUNTY_NAME = c("Los Angeles", "X", "Madison"),
-    ARPT_NAME = c("Los Angeles Intl", "Helipad", "Frerichs"),
-    LAT_DEG = c(33L, 34L, 34L), LAT_MIN = c(56L, 0L, 42L),
-    LAT_SEC = c("33.00", "0.00", "0.00"), LAT_HEMIS = "N",
-    LAT_DECIMAL = c(33.94, 34.0, 34.7),
-    LONG_DEG = c(118L, 86L, 86L), LONG_MIN = c(24L, 0L, 21L),
-    LONG_SEC = c("29.00", "0.00", "0.00"), LONG_HEMIS = "W",
-    LONG_DECIMAL = c(-118.41, -86.0, -86.35),
-    ELEV = c(128, 600, 700),
-    ELEV_METHOD_CODE = "S",
-    MAG_VARN = c(13.0, 2.0, 2.0), MAG_HEMIS = "W", MAG_VARN_YEAR = 2020L,
-    ICAO_ID = c("KLAX", "", ""),
-    FACILITY_USE_CODE = c("PU", "PR", "PR")
-  )
-  write.csv(test_data, temp_file, row.names = FALSE)
-
-  result <- clean_airports(temp_file)
-
-  expect_true("AL10" %in% result$ARPT_ID) # 4-char private LID retained
-  expect_true("0AL1" %in% result$ARPT_ID) # heliport retained
-  expect_equal(nrow(result), 3) # no rows dropped
-})
-
-test_that("clean_airports maps PU/PR to public/private", {
-  temp_dir <- withr::local_tempdir()
-  temp_file <- file.path(temp_dir, "APT_BASE.csv")
-  test_data <- data.frame(
-    stringsAsFactors = FALSE,
-    EFF_DATE = "12/19/2024", SITE_NO = c("00001", "00002"),
-    SITE_TYPE_CODE = "A", STATE_CODE = c("CA", "AL"),
-    ARPT_ID = c("LAX", "AL10"), CITY = c("Los Angeles", "Gurley"),
-    COUNTRY_CODE = "US", STATE_NAME = c("California", "Alabama"),
-    COUNTY_NAME = c("Los Angeles", "Madison"),
-    ARPT_NAME = c("Los Angeles Intl", "Frerichs"),
-    LAT_DEG = c(33L, 34L), LAT_MIN = c(56L, 42L),
-    LAT_SEC = c("33.00", "0.00"), LAT_HEMIS = "N",
-    LAT_DECIMAL = c(33.94, 34.7),
-    LONG_DEG = c(118L, 86L), LONG_MIN = c(24L, 21L),
-    LONG_SEC = c("29.00", "0.00"), LONG_HEMIS = "W",
-    LONG_DECIMAL = c(-118.41, -86.35),
-    ELEV = c(128, 700), ELEV_METHOD_CODE = "S",
-    MAG_VARN = c(13.0, 2.0), MAG_HEMIS = "W", MAG_VARN_YEAR = 2020L,
-    ICAO_ID = c("KLAX", ""), FACILITY_USE_CODE = c("PU", "PR")
-  )
-  write.csv(test_data, temp_file, row.names = FALSE)
-
-  result <- clean_airports(temp_file)
-
-  expect_equal(result$facility_use[result$ARPT_ID == "LAX"], "public")
-  expect_equal(result$facility_use[result$ARPT_ID == "AL10"], "private")
-})
-
-test_that("clean_airports output has facility_use, not facility_use_code", {
-  temp_dir <- withr::local_tempdir()
-  temp_file <- file.path(temp_dir, "APT_BASE.csv")
-  test_data <- data.frame(
-    stringsAsFactors = FALSE,
-    EFF_DATE = "12/19/2024", SITE_NO = "00001", SITE_TYPE_CODE = "A",
-    STATE_CODE = "CA", ARPT_ID = "LAX", CITY = "Los Angeles",
-    COUNTRY_CODE = "US", STATE_NAME = "California", COUNTY_NAME = "LA",
-    ARPT_NAME = "Los Angeles Intl",
-    LAT_DEG = 33L, LAT_MIN = 56L, LAT_SEC = "33.00", LAT_HEMIS = "N",
-    LAT_DECIMAL = 33.94,
-    LONG_DEG = 118L, LONG_MIN = 24L, LONG_SEC = "29.00", LONG_HEMIS = "W",
-    LONG_DECIMAL = -118.41,
-    ELEV = 128, ELEV_METHOD_CODE = "S",
-    MAG_VARN = 13.0, MAG_HEMIS = "E", MAG_VARN_YEAR = 2020L,
-    ICAO_ID = "KLAX", FACILITY_USE_CODE = "PU"
-  )
-  write.csv(test_data, temp_file, row.names = FALSE)
-
-  result <- clean_airports(temp_file)
-
-  expect_true("facility_use" %in% names(result))
-  expect_false("facility_use_code" %in% tolower(names(result)))
-  expect_false("FACILITY_USE_CODE" %in% names(result))
-})
-
-test_that("clean_airports aborts on unknown facility-use code", {
-  temp_dir <- withr::local_tempdir()
-  temp_file <- file.path(temp_dir, "APT_BASE.csv")
-  test_data <- data.frame(
-    stringsAsFactors = FALSE,
-    EFF_DATE = "12/19/2024", SITE_NO = "00001", SITE_TYPE_CODE = "A",
-    STATE_CODE = "CA", ARPT_ID = "LAX", CITY = "Los Angeles",
-    COUNTRY_CODE = "US", STATE_NAME = "California", COUNTY_NAME = "LA",
-    ARPT_NAME = "Los Angeles Intl",
-    LAT_DEG = 33L, LAT_MIN = 56L, LAT_SEC = "33.00", LAT_HEMIS = "N",
-    LAT_DECIMAL = 33.94,
-    LONG_DEG = 118L, LONG_MIN = 24L, LONG_SEC = "29.00", LONG_HEMIS = "W",
-    LONG_DECIMAL = -118.41,
-    ELEV = 128, ELEV_METHOD_CODE = "S",
-    MAG_VARN = 13.0, MAG_HEMIS = "E", MAG_VARN_YEAR = 2020L,
-    ICAO_ID = "KLAX", FACILITY_USE_CODE = "ZZ" # invalid code
-  )
-  write.csv(test_data, temp_file, row.names = FALSE)
-
-  expect_error(
-    clean_airports(temp_file),
-    class = "clean_data_facility_use_error"
-  )
-})
-
-test_that("clean_airports returns expected columns", {
-  temp_dir <- withr::local_tempdir()
-  temp_file <- file.path(temp_dir, "APT_BASE.csv")
-
-  # Create minimal valid test data
-  test_data <- data.frame(
-    stringsAsFactors = FALSE,
-    EFF_DATE = "12/19/2024",
-    SITE_NO = "00001",
-    SITE_TYPE_CODE = "A",
-    STATE_CODE = "CA",
-    ARPT_ID = "LAX",
-    CITY = "Los Angeles",
-    COUNTRY_CODE = "US",
-    STATE_NAME = "California",
-    COUNTY_NAME = "Los Angeles",
-    ARPT_NAME = "Los Angeles Intl",
-    LAT_DEG = 33L, LAT_MIN = 56L, LAT_SEC = "33.00", LAT_HEMIS = "N",
-    LAT_DECIMAL = 33.94,
-    LONG_DEG = 118L, LONG_MIN = 24L, LONG_SEC = "29.00", LONG_HEMIS = "W",
-    LONG_DECIMAL = -118.41,
-    ELEV = 128,
-    ELEV_METHOD_CODE = "S",
-    MAG_VARN = 13.0, MAG_HEMIS = "E", MAG_VARN_YEAR = 2020L,
-    ICAO_ID = "KLAX",
-    FACILITY_USE_CODE = "PU",
-    EXTRA_COL = "should be dropped" # Extra column not in schema
-  )
-
-  write.csv(test_data, temp_file, row.names = FALSE)
-
-  result <- clean_airports(temp_file)
-
-  # Should have exactly the expected columns
-  expect_equal(sort(names(result)), sort(airports_columns))
-
-  # Extra column should be dropped
-  expect_false("EXTRA_COL" %in% names(result))
-})
-
-test_that("clean_airports aborts on missing columns", {
-  temp_dir <- withr::local_tempdir()
-  temp_file <- file.path(temp_dir, "APT_BASE.csv")
-
-  # Create data missing required columns
-  test_data <- data.frame(
-    stringsAsFactors = FALSE,
-    EFF_DATE = "12/19/2024",
-    ARPT_ID = "LAX"
-    # Missing many required columns
-  )
-
-  write.csv(test_data, temp_file, row.names = FALSE)
-
-  expect_error(
-    clean_airports(temp_file),
-    class = "clean_data_schema_error"
-  )
-})
-
 test_that("clean_navaids validates file path exists", {
   expect_error(
     clean_navaids("/nonexistent/path/NAV_BASE.csv"),
@@ -236,65 +52,6 @@ test_that("validate_cleaned_data requires valid schema_type", {
     validate_cleaned_data(data, "invalid_type"),
     "arg"
   )
-})
-
-test_that("validate_cleaned_data accepts 4-char ARPT_IDs", {
-  data <- sample_airports(3)
-  names(data) <- toupper(names(data))
-  names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
-  data$ARPT_ID <- c("LAX", "AL10", "0AL1") # mixed 3/4-char now valid
-
-  result <- withCallingHandlers(
-    validate_cleaned_data(data, "airports"),
-    validation_warning = function(w) invokeRestart("muffleWarning")
-  )
-  expect_s3_class(result, "data.frame")
-  expect_equal(nrow(result), 3)
-  expect_true(all(c("AL10", "0AL1") %in% result$ARPT_ID))
-})
-
-test_that("validate_cleaned_data aborts when facility_use column is missing", {
-  data <- sample_airports(3)
-  names(data) <- toupper(names(data))
-  names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
-  data$facility_use <- NULL # remove the column entirely
-
-  expect_error(
-    withCallingHandlers(
-      validate_cleaned_data(data, "airports"),
-      validation_warning = function(w) invokeRestart("muffleWarning")
-    ),
-    class = "validation_error"
-  )
-})
-
-test_that("validate_cleaned_data aborts on invalid facility_use", {
-  data <- sample_airports(3)
-  names(data) <- toupper(names(data))
-  names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
-  data$facility_use <- c("public", "private", "bogus")
-
-  expect_error(
-    withCallingHandlers(
-      validate_cleaned_data(data, "airports"),
-      validation_warning = function(w) invokeRestart("muffleWarning")
-    ),
-    class = "validation_error"
-  )
-})
-
-test_that("validate_cleaned_data warns but does not drop out-of-range coords", {
-  data <- sample_airports(2)
-  names(data) <- toupper(names(data))
-  names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
-  data$LAT_DECIMAL <- c(13.4, 33.94) # Guam-like latitude (< 18) included
-  data$LONG_DECIMAL <- c(144.8, -118.4) # Guam-like longitude (> -64) included
-
-  result <- withCallingHandlers(
-    validate_cleaned_data(data, "airports"),
-    validation_warning = function(w) invokeRestart("muffleWarning")
-  )
-  expect_equal(nrow(result), 2) # nothing filtered
 })
 
 test_that("find_raw_data_dirs validates directory exists", {
@@ -358,4 +115,31 @@ test_that("remove_extra_files handles missing files gracefully", {
   result <- remove_extra_files(apt_dir, nav_dir)
 
   expect_equal(result, 0)
+})
+
+test_that("navaids validation warns on low row count", {
+  data <- sample_navaids(3) # 3 rows, all NAV_TYPE values valid
+  names(data) <- toupper(names(data))
+
+  expect_warning(
+    validate_cleaned_data(data, "navaids"),
+    class = "validation_warning"
+  )
+})
+
+test_that("navaids validation warns on unexpected NAV_TYPE", {
+  data <- sample_navaids(3)
+  names(data) <- toupper(names(data))
+  data$NAV_TYPE <- c("VOR", "NDB", "MADE_UP_TYPE")
+
+  # Low row count also warns; collect all warnings, then check content
+  warnings_seen <- character()
+  withCallingHandlers(
+    validate_cleaned_data(data, "navaids"),
+    validation_warning = function(w) {
+      warnings_seen <<- c(warnings_seen, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    }
+  )
+  expect_true(any(grepl("MADE_UP_TYPE", warnings_seen)))
 })


### PR DESCRIPTION
Closes #16 (items 1, 2, 4; item 3 landed in #19).

- clean_data.R (356 lines) split by domain: airports schema, map_facility_use(), clean_airports(), and a new validate_airports() move to clean_airports.R (168 lines); clean_data.R (236 lines) keeps navaids cleaning, shared helpers, and a thin validate_cleaned_data() dispatcher with unchanged signature.
- Airports validation reordered fail-fast: structural aborts (facility_use presence, value domain) before the row-count and coordinate-range warnings. Pinned by a new test that fails against the old ordering.
- Clean-stage outputs verified byte-identical pre/post refactor against the 2026-05-14 raw data (md5-confirmed in review).
- validate_navaids() gains direct warning coverage (new function per CONTRIBUTING's per-function test rule). Suite: 117 pass / 0 fail / 1 expected skip; lint: 0 across R/ and tests/.
- Dead SendGrid/Twilio scaffolding removed from .Renviron.example; the live gh-issue notify steps in daily-pipeline.yml are untouched.
- README and CONTRIBUTING updated for the new file and the repo-wide lint gate.

Generated with [Claude Code](https://claude.com/claude-code)