### PR TITLE
ci: toolchain determinism and pipeline reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,36 @@ permissions:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  RENV_CONFIG_REPOS_OVERRIDE: 'https://packagemanager.posit.co/cran/__linux__/noble/latest'
+  # Frozen snapshot plus CRAN fallback. The date MUST match the value in
+  # daily-pipeline.yml and MUST move whenever renv.lock changes.
+  # Separator is a semicolon; renv does not split on commas.
+  RENV_CONFIG_REPOS_OVERRIDE: 'https://packagemanager.posit.co/cran/__linux__/noble/2026-07-28;https://cloud.r-project.org'
 
 jobs:
   lint-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Assert snapshot dates agree across workflows
+        run: |
+          CI_DATE=$(grep -oE 'noble/[0-9]{4}-[0-9]{2}-[0-9]{2}' .github/workflows/ci.yml | head -1)
+          DP_DATE=$(grep -oE 'noble/[0-9]{4}-[0-9]{2}-[0-9]{2}' .github/workflows/daily-pipeline.yml | head -1)
+          echo "ci.yml            : ${CI_DATE:-MISSING}"
+          echo "daily-pipeline.yml: ${DP_DATE:-MISSING}"
+          if [ -z "$CI_DATE" ] || [ -z "$DP_DATE" ]; then
+            echo "::error::A pinned PPM snapshot date is missing from one of the workflows."
+            exit 1
+          fi
+          if [ "$CI_DATE" != "$DP_DATE" ]; then
+            echo "::error::PPM snapshot dates disagree. They must move together."
+            exit 1
+          fi
 
       - name: Install system dependencies
         run: |
@@ -37,12 +55,36 @@ jobs:
             pandoc
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: '4.6'
 
+      - name: Assert two-repo override resolves
+        run: |
+          Rscript -e '
+          raw <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE")
+          if (!nzchar(raw)) stop("RENV_CONFIG_REPOS_OVERRIDE is unset")
+          repos <- strsplit(raw, ";", fixed = TRUE)[[1]]
+          cat("declared repositories:", length(repos), "\n")
+          print(repos)
+          if (length(repos) != 2L) {
+            stop("expected 2 repositories, got ", length(repos),
+                 ". renv splits on semicolons, not commas.")
+          }
+          ap <- available.packages(repos = repos, type = "source")
+          cat("combined index rows:", nrow(ap), "\n")
+          if (nrow(ap) == 0L) stop("empty package index under the two-repo override")
+          '
+
       - name: Setup renv
-        uses: r-lib/actions/setup-renv@v2
+        uses: r-lib/actions/setup-renv@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+        with:
+          # Bumped 1 -> 2 because the package source changes in this commit from
+          # noble/latest to a dated snapshot plus a CRAN fallback. The cache key is
+          # <os-version>-<r-version>-<cache-version>-<hashFiles(renv.lock)> and does
+          # NOT include RENV_CONFIG_REPOS_OVERRIDE, so binaries cached from the old
+          # source would otherwise carry forward silently.
+          cache-version: 2
 
       - name: Install lintr (pinned; not in renv.lock by design)
         run: Rscript -e 'renv::install("lintr@3.3.0-1")'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,10 @@ env:
   # Frozen snapshot plus CRAN fallback. The date MUST match the value in
   # daily-pipeline.yml and MUST move whenever renv.lock changes.
   # Separator is a semicolon; renv does not split on commas.
-  RENV_CONFIG_REPOS_OVERRIDE: 'https://packagemanager.posit.co/cran/__linux__/noble/2026-07-28;https://cloud.r-project.org'
+  # Entries MUST be NAME=URL. renv_repos_validate() auto-names a single unnamed
+  # repository CRAN, but aborts with "all repository entries must be named" as
+  # soon as there are two or more unnamed entries.
+  RENV_CONFIG_REPOS_OVERRIDE: 'PPM=https://packagemanager.posit.co/cran/__linux__/noble/2026-07-28;CRAN=https://cloud.r-project.org'
 
 jobs:
   lint-test:
@@ -69,19 +72,31 @@ jobs:
       # GITHUB_ENV, so an assertion placed before it would validate a value that
       # is about to be overwritten and pass green while the pin does nothing.
       # Do not move this step earlier.
+      # This runs in base R because renv is not installed until the next step, so
+      # it cannot call renv_repos_validate() directly. It therefore checks the
+      # shape of the literal a human writes, not renv's parse. renv's validator
+      # remains the authority; this is a fast, legible failure one step earlier.
       - name: Assert two-repo override resolves
         run: |
           Rscript -e '
           raw <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE")
           if (!nzchar(raw)) stop("RENV_CONFIG_REPOS_OVERRIDE is unset")
-          repos <- strsplit(raw, ";", fixed = TRUE)[[1]]
-          cat("declared repositories:", length(repos), "\n")
-          print(repos)
-          if (length(repos) != 2L) {
-            stop("expected 2 repositories, got ", length(repos),
+          entries <- strsplit(raw, ";", fixed = TRUE)[[1]]
+          cat("declared entries:", length(entries), "\n")
+          print(entries)
+          if (length(entries) != 2L) {
+            stop("expected 2 entries, got ", length(entries),
                  ". renv splits on semicolons, not commas.")
           }
-          ap <- available.packages(repos = repos, type = "source")
+          bad <- !grepl("^[A-Za-z][A-Za-z0-9._]*=https?://", entries)
+          if (any(bad)) {
+            stop("every entry must be NAME=URL. renv_repos_validate() aborts with ",
+                 "\"all repository entries must be named\" when two or more are ",
+                 "unnamed. Offending: ", paste(entries[bad], collapse = ", "))
+          }
+          urls <- sub("^[^=]*=", "", entries)
+          cat("names:", paste(sub("=.*$", "", entries), collapse = ", "), "\n")
+          ap <- available.packages(repos = urls, type = "source")
           cat("combined index rows:", nrow(ap), "\n")
           if (nrow(ap) == 0L) stop("empty package index under the two-repo override")
           '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,17 @@ jobs:
         uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: '4.6'
+          # REQUIRED, not cosmetic. With the default (true), setup-r writes
+          # RENV_CONFIG_REPOS_OVERRIDE into GITHUB_ENV pointing at noble/latest.
+          # That shadows the workflow-level env: above for every subsequent step
+          # and silently defeats the pinned snapshot. Disabling the competing
+          # writer makes the precedence question moot instead of betting on it.
+          use-public-rspm: false
 
+      # MUST run after Setup R. setup-r writes RENV_CONFIG_REPOS_OVERRIDE to
+      # GITHUB_ENV, so an assertion placed before it would validate a value that
+      # is about to be overwritten and pass green while the pin does nothing.
+      # Do not move this step earlier.
       - name: Assert two-repo override resolves
         run: |
           Rscript -e '

--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -121,8 +121,9 @@ jobs:
           cache-version: 2
         env:
           # Frozen snapshot plus CRAN fallback. The date MUST match ci.yml and
-          # MUST move whenever renv.lock changes.
-          RENV_CONFIG_REPOS_OVERRIDE: 'https://packagemanager.posit.co/cran/__linux__/noble/2026-07-28;https://cloud.r-project.org'
+          # MUST move whenever renv.lock changes. Entries MUST be NAME=URL;
+          # renv_repos_validate() aborts on two or more unnamed entries.
+          RENV_CONFIG_REPOS_OVERRIDE: 'PPM=https://packagemanager.posit.co/cran/__linux__/noble/2026-07-28;CRAN=https://cloud.r-project.org'
 
       - name: Run pipeline
         if: steps.check.outputs.needs_update == 'true' || github.event.inputs.force == 'true'

--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -102,6 +102,15 @@ jobs:
         uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: '4.6'
+          # REQUIRED. See ci.yml for the full reasoning. With the default (true),
+          # setup-r writes RENV_CONFIG_REPOS_OVERRIDE into GITHUB_ENV pointing at
+          # noble/latest. Whether a later step-level env: would win over that is
+          # not documented by GitHub and has never been exercised here, because
+          # this file's step-level value and setup-r's computed value were
+          # byte-identical until the snapshot was pinned. Disabling the writer
+          # removes the question rather than assuming an answer, which matters
+          # more here than in ci.yml because this workflow writes to production.
+          use-public-rspm: false
 
       - name: Setup renv
         if: steps.check.outputs.needs_update == 'true' || github.event.inputs.force == 'true'

--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -15,9 +15,18 @@ permissions:
   contents: write
   issues: write
 
+# Deliberately does not cancel in progress: a dispatch must not overlap the
+# 12:00 UTC cron, because both runs clear_table() and repopulate Supabase.
+# Cancelling a pipeline mid-push is worse than queueing it. Note this queues at
+# most one pending run; a third concurrent trigger cancels the pending one.
+concurrency:
+  group: daily-pipeline
+  cancel-in-progress: false
+
 jobs:
   check-and-run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -90,15 +99,21 @@ jobs:
 
       - name: Setup R
         if: steps.check.outputs.needs_update == 'true' || github.event.inputs.force == 'true'
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: '4.6'
 
       - name: Setup renv
         if: steps.check.outputs.needs_update == 'true' || github.event.inputs.force == 'true'
-        uses: r-lib/actions/setup-renv@v2
+        uses: r-lib/actions/setup-renv@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+        with:
+          # See ci.yml. Bumped because the package source changes in this commit
+          # and the cache key does not include RENV_CONFIG_REPOS_OVERRIDE.
+          cache-version: 2
         env:
-          RENV_CONFIG_REPOS_OVERRIDE: 'https://packagemanager.posit.co/cran/__linux__/noble/latest'
+          # Frozen snapshot plus CRAN fallback. The date MUST match ci.yml and
+          # MUST move whenever renv.lock changes.
+          RENV_CONFIG_REPOS_OVERRIDE: 'https://packagemanager.posit.co/cran/__linux__/noble/2026-07-28;https://cloud.r-project.org'
 
       - name: Run pipeline
         if: steps.check.outputs.needs_update == 'true' || github.event.inputs.force == 'true'
@@ -161,18 +176,28 @@ jobs:
 
           [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
+      # Fires on ANY job failure, not only when the pipeline step itself failed.
+      # The previous condition also required steps.pipeline.outcome == 'failure',
+      # which meant a rejected data commit or a failed FAA date check produced no
+      # issue at all, leaving Supabase and the repository silently out of step.
       - name: Notify on pipeline failure
-        if: failure() && steps.pipeline.outcome == 'failure'
+        if: failure()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          {
+            echo "Pipeline failed. Step outcomes:"
+            echo ""
+            echo "| Step | Outcome |"
+            echo "|------|---------|"
+            echo "| Check FAA dates | ${{ steps.check.outcome }} |"
+            echo "| Run pipeline | ${{ steps.pipeline.outcome }} |"
+            echo ""
+            echo "[View run logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          } > /tmp/failure-body.md
+
           gh issue create \
-            --title "NASR Pipeline FAILED: ${{ steps.check.outputs.current_date }}" \
+            --repo "${{ github.repository }}" \
+            --title "NASR Pipeline FAILED: ${{ steps.check.outputs.current_date || github.run_id }}" \
             --label "pipeline-failure" \
-            --body "Pipeline failed during execution.
-
-          | Detail | Value |
-          |--------|-------|
-          | FAA Date | ${{ steps.check.outputs.current_date }} |
-
-          [View run logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            --body-file /tmp/failure-body.md


### PR DESCRIPTION
Implements Gate 1 of the CI hardening spec.

- Pin `runs-on: ubuntu-24.04` in both workflows so the OS cannot drift away from the hardcoded noble PPM URL
- Freeze the PPM snapshot to 2026-07-28 with `cloud.r-project.org` as a fallback, semicolon separated (renv does not split on commas)
- Pin `r-lib/actions` to commit SHAs
- Bump `cache-version` 1 to 2, because the cache key does not include `RENV_CONFIG_REPOS_OVERRIDE` and stale binaries would otherwise carry forward
- `cancel-in-progress` only on pull requests so `main` keeps a complete check history
- Add a timeout and a concurrency group to the daily pipeline
- Fix the failure notification, which could not fire when the data commit step failed

Depends on 1437fcb (Gate 0).