### PR TITLE
ci(pipeline): daily override assertions, workflow-level scope

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -23,6 +23,19 @@ concurrency:
   group: daily-pipeline
   cancel-in-progress: false
 
+env:
+  # Workflow level, matching ci.yml, so both files carry exactly one literal in
+  # the same position. Previously declared at step level on Setup renv; that
+  # placement was justified as "defense in depth" against setup-r writing this
+  # variable into GITHUB_ENV, but use-public-rspm: false removed that competing
+  # writer, and step scope put the value out of reach of the ungated shape check
+  # below and of the effective-value check after Setup R.
+  #
+  # The date MUST match ci.yml and MUST move whenever renv.lock changes.
+  # Entries MUST be NAME=URL; renv_repos_validate() aborts on two or more
+  # unnamed entries.
+  RENV_CONFIG_REPOS_OVERRIDE: 'PPM=https://packagemanager.posit.co/cran/__linux__/noble/2026-07-28;CRAN=https://cloud.r-project.org'
+
 jobs:
   check-and-run:
     runs-on: ubuntu-24.04
@@ -37,29 +50,25 @@ jobs:
       # A malformed override would otherwise surface on cycle day, during the run
       # that matters, with the next chance to observe it four weeks later.
       #
-      # This validates the LITERAL AS WRITTEN in this file, not the effective
-      # value at runtime. It cannot read the environment variable: the override is
-      # declared at step level on Setup renv, which is inside the gate, so nothing
-      # is in scope here. A separate check after Setup R validates the effective
-      # value on cycle day. Do not mistake this one for that stronger guarantee.
-      - name: Assert repository override literal is well formed
+      # This reads the DECLARED value, before Setup R runs. It is not the
+      # effective value that renv will ultimately receive: setup-r can write this
+      # variable into GITHUB_ENV and shadow it, which is why use-public-rspm is
+      # set to false below. The "Assert override survived Setup R" step inside the
+      # gate covers that case. Do not mistake this check for that guarantee.
+      #
+      # An earlier draft grepped this file for the literal instead of reading the
+      # variable. That form matched its own source text, because the grep pattern
+      # necessarily appears in the file being grepped, and head -1 returned the
+      # self-match, yielding "literal: [^". Moving the override to workflow level
+      # put it in scope here and deleted that entire failure mode rather than
+      # anchoring around it.
+      - name: Assert repository override is well formed
         run: |
           set -euo pipefail
-          FILE=.github/workflows/daily-pipeline.yml
 
-          # The pattern is anchored to the start of the line because this step
-          # lives in the very file it greps. An unanchored pattern matches its own
-          # source text and head -1 then returns that self-match instead of the
-          # declaration. Verified: the unanchored form yielded "literal: [^".
-          #
-          # || true is required: under set -o pipefail a non-matching grep kills
-          # the pipeline and set -e exits before the empty-literal branch below
-          # can report, leaving a bare exit 1 with no diagnostic.
-          LINE=$(grep -E "^[[:space:]]*RENV_CONFIG_REPOS_OVERRIDE:" "$FILE" | head -1 || true)
-          LITERAL=$(printf '%s' "$LINE" | sed "s/^[^']*'//; s/'.*$//")
-
+          LITERAL="${RENV_CONFIG_REPOS_OVERRIDE:-}"
           if [ -z "$LITERAL" ]; then
-            echo "::error::No RENV_CONFIG_REPOS_OVERRIDE literal found in $FILE"
+            echo "::error::RENV_CONFIG_REPOS_OVERRIDE is unset or empty"
             exit 1
           fi
           echo "literal: $LITERAL"
@@ -163,18 +172,47 @@ jobs:
           # more here than in ci.yml because this workflow writes to production.
           use-public-rspm: false
 
+      # Runs AFTER Setup R, so it observes the EFFECTIVE value rather than the
+      # declared one. This is the regression detector for use-public-rspm: if that
+      # input is ever removed or flipped back to its "true" default, setup-r writes
+      # RENV_CONFIG_REPOS_OVERRIDE into GITHUB_ENV pointing at noble/latest, the
+      # workflow-level declaration is shadowed, and this step fails here rather
+      # than letting renv restore from the wrong repository on the one run per
+      # cycle that writes to Supabase.
+      #
+      # Gated, so it runs only on cycle day. The ungated shape check near the top
+      # of this job gives the daily signal on the declared value.
+      - name: Assert override survived Setup R
+        if: steps.check.outputs.needs_update == 'true' || github.event.inputs.force == 'true'
+        run: |
+          Rscript -e '
+          raw <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE")
+          if (!nzchar(raw)) stop("RENV_CONFIG_REPOS_OVERRIDE is unset after Setup R")
+          entries <- strsplit(raw, ";", fixed = TRUE)[[1]]
+          cat("effective entries:", length(entries), "\n")
+          print(entries)
+          if (length(entries) != 2L) {
+            stop("expected 2 entries, got ", length(entries),
+                 ". If this reads noble/latest, setup-r shadowed the declared ",
+                 "value; check use-public-rspm.")
+          }
+          bad <- !grepl("^[A-Za-z][A-Za-z0-9._]*=https?://", entries)
+          if (any(bad)) {
+            stop("every entry must be NAME=URL. renv_repos_validate() aborts with ",
+                 "\"all repository entries must be named\" when two or more are ",
+                 "unnamed. Offending: ", paste(entries[bad], collapse = ", "))
+          }
+          cat("names:", paste(sub("=.*$", "", entries), collapse = ", "), "\n")
+          '
+
       - name: Setup renv
         if: steps.check.outputs.needs_update == 'true' || github.event.inputs.force == 'true'
         uses: r-lib/actions/setup-renv@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           # See ci.yml. Bumped because the package source changes in this commit
           # and the cache key does not include RENV_CONFIG_REPOS_OVERRIDE.
+          # The repository override is declared at workflow level, not here.
           cache-version: 2
-        env:
-          # Frozen snapshot plus CRAN fallback. The date MUST match ci.yml and
-          # MUST move whenever renv.lock changes. Entries MUST be NAME=URL;
-          # renv_repos_validate() aborts on two or more unnamed entries.
-          RENV_CONFIG_REPOS_OVERRIDE: 'PPM=https://packagemanager.posit.co/cran/__linux__/noble/2026-07-28;CRAN=https://cloud.r-project.org'
 
       - name: Run pipeline
         if: steps.check.outputs.needs_update == 'true' || github.event.inputs.force == 'true'

--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -31,6 +31,57 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Deliberately UNGATED, so it runs on every daily check rather than only on
+      # cycle day. Everything below the needs_update gate executes roughly once
+      # per 28-day cycle, and that execution is the one that writes to Supabase.
+      # A malformed override would otherwise surface on cycle day, during the run
+      # that matters, with the next chance to observe it four weeks later.
+      #
+      # This validates the LITERAL AS WRITTEN in this file, not the effective
+      # value at runtime. It cannot read the environment variable: the override is
+      # declared at step level on Setup renv, which is inside the gate, so nothing
+      # is in scope here. A separate check after Setup R validates the effective
+      # value on cycle day. Do not mistake this one for that stronger guarantee.
+      - name: Assert repository override literal is well formed
+        run: |
+          set -euo pipefail
+          FILE=.github/workflows/daily-pipeline.yml
+
+          # The pattern is anchored to the start of the line because this step
+          # lives in the very file it greps. An unanchored pattern matches its own
+          # source text and head -1 then returns that self-match instead of the
+          # declaration. Verified: the unanchored form yielded "literal: [^".
+          #
+          # || true is required: under set -o pipefail a non-matching grep kills
+          # the pipeline and set -e exits before the empty-literal branch below
+          # can report, leaving a bare exit 1 with no diagnostic.
+          LINE=$(grep -E "^[[:space:]]*RENV_CONFIG_REPOS_OVERRIDE:" "$FILE" | head -1 || true)
+          LITERAL=$(printf '%s' "$LINE" | sed "s/^[^']*'//; s/'.*$//")
+
+          if [ -z "$LITERAL" ]; then
+            echo "::error::No RENV_CONFIG_REPOS_OVERRIDE literal found in $FILE"
+            exit 1
+          fi
+          echo "literal: $LITERAL"
+
+          IFS=';' read -r -a ENTRIES <<< "$LITERAL"
+          echo "declared entries: ${#ENTRIES[@]}"
+
+          if [ "${#ENTRIES[@]}" -ne 2 ]; then
+            echo "::error::expected 2 entries, got ${#ENTRIES[@]}. renv splits on semicolons, not commas."
+            exit 1
+          fi
+
+          for e in "${ENTRIES[@]}"; do
+            if ! printf '%s' "$e" | grep -qE '^[A-Za-z][A-Za-z0-9._]*=https?://'; then
+              echo "::error::every entry must be NAME=URL. renv_repos_validate() aborts with \"all repository entries must be named\" when two or more are unnamed. Offending: $e"
+              exit 1
+            fi
+          done
+
+          echo "names: $(printf '%s\n' "${ENTRIES[@]}" | sed 's/=.*$//' | paste -sd, -)"
+          echo "literal is well formed"
+
       - name: Check FAA dates
         id: check
         run: |


### PR DESCRIPTION
Gate 2a. Moves `RENV_CONFIG_REPOS_OVERRIDE` to workflow level in `daily-pipeline.yml` and adds two assertions: an ungated shape check reading the declared value every day, and a gated effective-value check after `Setup R` that detects `use-public-rspm` regressions on cycle day.

Both demonstrated failing on the inputs they exist to catch.