### PR TITLE
docs: CI maintenance contract and assertion rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,13 @@ Rscript -e "renv::restore()"
 Rscript -e "renv::install('package_name')"
 
 # Snapshot current packages
-Rscript -e "renv::snapshot(type = 'all')"
+Rscript -e "renv::snapshot(type = 'implicit')"
 ```
+
+The type is set to `implicit` in `renv/settings.json`. Passing it explicitly keeps
+the command honest if that setting ever changes. This previously read
+`type = 'all'`, which contradicts the project setting and would snapshot every
+package in the library, including ones that are not project dependencies.
 
 ### Run Pipeline
 
@@ -76,6 +81,56 @@ All enforced gates must pass before merge.
 | Function size limit | Functions should stay under 80 lines |
 | Fail-loud conventions | No `suppressWarnings()`, `suppressMessages()`, or `tryCatch` without approval |
 | Tidyverse style | Follow tidyverse conventions; use `styler` for formatting |
+
+## CI Toolchain Maintenance
+
+Both workflows pin the runner image and a dated Posit Package Manager snapshot.
+That buys reproducible builds, and it creates five standing obligations. Each one
+below was learned by breaking it; none is inferable from reading the workflow
+files cold.
+
+1. **When `renv.lock` changes, move the PPM snapshot date in both
+   `.github/workflows/ci.yml` and `.github/workflows/daily-pipeline.yml`, in the
+   same commit.** A package version that postdates the frozen snapshot does not
+   exist in it and falls back to a slow source build from CRAN. A CI assertion
+   fails the build if the two dates disagree.
+2. **When Ubuntu 24.04 nears end of standard support (April 2029), bump the
+   `runs-on` value and the PPM codename together.** They are a matched pair;
+   changing one alone reintroduces the drift the pin was added to prevent.
+3. **Review the pinned `r-lib/actions` commit SHAs periodically.** Pinned SHAs do
+   not receive upstream security fixes automatically.
+4. **`use-public-rspm: false` must stay on both `Setup R` steps.** Without it,
+   `setup-r` writes `RENV_CONFIG_REPOS_OVERRIDE` into `GITHUB_ENV`, which shadows
+   the workflow-level value for every later step and silently defeats the pinned
+   snapshot. `ci.yml`'s two-repo assertion catches this on every run;
+   `daily-pipeline.yml`'s post-`Setup R` assertion catches it on cycle day.
+5. **The override must use the `NAME=URL` form.** `renv_repos_validate()`
+   auto-names a single unnamed repository `CRAN`, but aborts with
+   `all repository entries must be named` on two or more. An unnamed two-entry
+   override fails `renv::restore()` outright, and `available.packages()`
+   tolerating it proves nothing, because that is not the function which validates
+   names.
+
+The second repository in `RENV_CONFIG_REPOS_OVERRIDE` is a deliberate fallback.
+The separator is a semicolon; renv does not split on commas. A package the
+snapshot lacks resolves from CRAN as a source build, so the build degrades in time
+rather than failing.
+
+`lintr` is pinned outside `renv.lock` and is excluded from the "zero source
+builds" expectation however it resolves.
+
+## Assertions in CI
+
+An assertion added to CI must be demonstrated to fail on the input it exists to
+catch, and that demonstration is part of the change's evidence. An assertion that
+has never been observed failing is an untested branch.
+
+Two assertions in this repository passed on input the system rejects before they
+were strengthened. A third exited with a bare status code and no diagnostic on its
+failure path. A fourth, which read the file it was embedded in, matched its own
+source text; standalone fixtures could not reproduce that, because they read a
+different file. When an assertion's input includes the assertion, exercise it in
+place, never on a copy.
 
 ## Branch and PR Workflow
 


### PR DESCRIPTION
Task 8 of the CI hardening work.

- Corrects `CONTRIBUTING.md:46` from `renv::snapshot(type = 'all')` to `implicit`, matching `renv/settings.json`
- Records the five standing obligations the snapshot and runner pins create
- Records the assertion rule: an assertion must be demonstrated failing on the input it exists to catch