### PR TITLE
ci(keep-alive): publishable key, row count floor, timeout; pipeline to 11:30Z

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -2,11 +2,12 @@ name: Daily FAA Data Pipeline
 
 on:
   schedule:
-    # 11:30 UTC, ahead of keep-alive.yml at 12:00 UTC, so this workflow's
-    # delete-then-insert window has normally closed before that check queries
-    # row counts. GitHub delays scheduled runs under load, so treat the offset as
-    # a courtesy rather than a guarantee; keep-alive.yml retries for that reason.
-    - cron: '30 11 * * *'
+    # 14:00 UTC. The FAA does not publish a new NASR cycle as early as 07:30
+    # Washington time, so an earlier cron only burns runs finding nothing. In
+    # practice this lands later still: GitHub delays scheduled runs under load,
+    # observed 1.5 to 2.5 hours on this repository, so roughly 11:30 to 12:30
+    # Washington time.
+    - cron: '0 14 * * *'
   workflow_dispatch:
     inputs:
       force:
@@ -20,7 +21,7 @@ permissions:
   issues: write
 
 # Deliberately does not cancel in progress: a dispatch must not overlap the
-# 11:30 UTC cron, because both runs clear_table() and repopulate Supabase.
+# 14:00 UTC cron, because both runs clear_table() and repopulate Supabase.
 # Cancelling a pipeline mid-push is worse than queueing it. Note this queues at
 # most one pending run; a third concurrent trigger cancels the pending one.
 concurrency:

--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -2,7 +2,11 @@ name: Daily FAA Data Pipeline
 
 on:
   schedule:
-    - cron: '0 12 * * *'
+    # 11:30 UTC, ahead of keep-alive.yml at 12:00 UTC, so this workflow's
+    # delete-then-insert window has normally closed before that check queries
+    # row counts. GitHub delays scheduled runs under load, so treat the offset as
+    # a courtesy rather than a guarantee; keep-alive.yml retries for that reason.
+    - cron: '30 11 * * *'
   workflow_dispatch:
     inputs:
       force:
@@ -16,7 +20,7 @@ permissions:
   issues: write
 
 # Deliberately does not cancel in progress: a dispatch must not overlap the
-# 12:00 UTC cron, because both runs clear_table() and repopulate Supabase.
+# 11:30 UTC cron, because both runs clear_table() and repopulate Supabase.
 # Cancelling a pipeline mid-push is worse than queueing it. Note this queues at
 # most one pending run; a third concurrent trigger cancels the pending one.
 concurrency:

--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -12,7 +12,7 @@ on:
       force:
         description: 'Force download even if data is current'
         required: false
-        default: 'false'
+        default: false
         type: boolean
 
 permissions:

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -2,22 +2,80 @@ name: Keep Supabase Active
 
 on:
   schedule:
-    # Runs daily at 12:00 UTC
+    # 12:00 UTC. daily-pipeline.yml runs at 11:30 UTC so its delete-then-insert
+    # window has normally closed before this check runs. That ordering is NOT
+    # guaranteed: GitHub delays scheduled runs under load, observed 1.5 to 2.5
+    # hours on this repository. The retry below is what actually prevents a false
+    # alarm, not the 30 minute offset.
     - cron: '0 12 * * *'
   workflow_dispatch: # Allow manual trigger
 
 jobs:
   ping:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      # PUBLISHABLE key, deliberately, not the secret key. This check needs only
+      # SELECT on airports, which RLS grants to anon. Verified 2026-07-30: this
+      # exact request returns 206 with the publishable key. Do NOT switch this to
+      # SUPABASE_API_KEY if it starts failing; a 401 here means an RLS or key
+      # rotation problem, and the write-capable key would hide it rather than fix
+      # it.
+      SUPABASE_KEY: ${{ secrets.SUPABASE_PUBLIC_KEY }}
+      TABLE_URL: 'https://bjmjxipflycjnrwdujxp.supabase.co/rest/v1/airports'
+      # A floor, not an exact count. Observed cycle counts: 19410, 19408, 19436.
+      # Catches an empty or badly partial table without tripping on normal
+      # cycle-to-cycle variation. A status code alone cannot: an empty table
+      # answers a ranged request successfully.
+      MIN_AIRPORTS: '19000'
     steps:
-      - name: Ping Supabase API
+      - name: Ping Supabase and assert a row count floor
         run: |
-          response=$(curl -s -o /dev/null -w "%{http_code}" \
-            "https://bjmjxipflycjnrwdujxp.supabase.co/rest/v1/airports?limit=1" \
-            -H "apikey: ${{ secrets.SUPABASE_API_KEY }}")
-          echo "Response code: $response"
-          if [ "$response" -ne 200 ]; then
-            echo "Warning: API returned $response"
+          set -uo pipefail
+
+          # PostgREST answers a ranged request with 206 Partial Content and puts
+          # the exact total after the slash: "content-range: 0-0/19436".
+          probe() {
+            curl -s -D /tmp/headers -o /dev/null \
+              "${TABLE_URL}?select=id" \
+              -H "apikey: ${SUPABASE_KEY}" \
+              -H "Prefer: count=exact" \
+              -H "Range: 0-0"
+            STATUS=$(awk 'toupper($1) ~ /^HTTP/ {print $2}' /tmp/headers | tail -1)
+            COUNT=$(tr -d '\r' < /tmp/headers |
+              awk -F'/' 'tolower($0) ~ /^content-range:/ {print $2}')
+          }
+
+          numeric_or_fail() {
+            case "${COUNT}" in
+              ''|*[!0-9]*)
+                echo "::error::Could not parse an exact row count from content-range"
+                exit 1
+                ;;
+            esac
+          }
+
+          probe
+          echo "status=${STATUS:-none} airports=${COUNT:-none}"
+
+          if [ "${STATUS}" != "206" ] && [ "${STATUS}" != "200" ]; then
+            echo "::error::Supabase returned HTTP ${STATUS:-no-response}"
             exit 1
           fi
-          echo "Supabase is active!"
+          numeric_or_fail
+
+          if [ "${COUNT}" -lt "${MIN_AIRPORTS}" ]; then
+            echo "airports=${COUNT} is below the floor ${MIN_AIRPORTS}."
+            echo "This can be daily-pipeline.yml's delete-then-insert window."
+            echo "Retrying once in 60s to tell that apart from a real outage."
+            sleep 60
+            probe
+            echo "retry status=${STATUS:-none} airports=${COUNT:-none}"
+            numeric_or_fail
+            if [ "${COUNT}" -lt "${MIN_AIRPORTS}" ]; then
+              echo "::error::airports=${COUNT} still below floor ${MIN_AIRPORTS} after retry"
+              exit 1
+            fi
+          fi
+
+          echo "Supabase is active. airports rows: ${COUNT}"

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -33,27 +33,44 @@ jobs:
         run: |
           set -uo pipefail
 
+          # Strip whitespace that GitHub secret handling can introduce. This is
+          # not defensive theatre: a newline inside a header value makes curl
+          # silently drop every LATER -H. apikey still authenticates, but Prefer
+          # and Range vanish, so the response is 200 with content-range total "*"
+          # instead of 206 with an exact count. Reproduced 2026-07-30 against a
+          # 47 character secret whose clean length is 46. R/push_to_supabase.R
+          # trims SUPABASE_API_KEY for the same reason.
+          KEY=$(printf '%s' "${SUPABASE_KEY}" | tr -d '[:space:]')
+          if [ -z "${KEY}" ]; then
+            echo "::error::SUPABASE_PUBLIC_KEY is empty"
+            exit 1
+          fi
+
           # PostgREST answers a ranged request with 206 Partial Content and puts
           # the exact total after the slash: "content-range: 0-0/19436".
           probe() {
             curl -s -D /tmp/headers -o /dev/null \
               "${TABLE_URL}?select=id" \
-              -H "apikey: ${SUPABASE_KEY}" \
+              -H "apikey: ${KEY}" \
               -H "Prefer: count=exact" \
               -H "Range: 0-0"
-            echo "curl_exit=$? key_len=${#SUPABASE_KEY}"
-            echo "--- raw response headers (responses carry no secrets) ---"
-            cat /tmp/headers
-            echo "--- end headers ---"
             STATUS=$(awk 'toupper($1) ~ /^HTTP/ {print $2}' /tmp/headers | tail -1)
             COUNT=$(tr -d '\r' < /tmp/headers |
               awk -F'/' 'tolower($0) ~ /^content-range:/ {print $2}')
           }
 
+          # Quiet on success, verbose on failure. Responses carry no secrets.
+          dump_headers() {
+            echo "--- raw response headers ---"
+            cat /tmp/headers
+            echo "--- end headers ---"
+          }
+
           numeric_or_fail() {
             case "${COUNT}" in
               ''|*[!0-9]*)
-                echo "::error::Could not parse an exact row count from content-range"
+                dump_headers
+                echo "::error::content-range total is '${COUNT:-empty}', not a number. A '*' means Prefer: count=exact was not applied, which happens when the apikey header value contains whitespace."
                 exit 1
                 ;;
             esac
@@ -63,6 +80,7 @@ jobs:
           echo "status=${STATUS:-none} airports=${COUNT:-none}"
 
           if [ "${STATUS}" != "206" ] && [ "${STATUS}" != "200" ]; then
+            dump_headers
             echo "::error::Supabase returned HTTP ${STATUS:-no-response}"
             exit 1
           fi
@@ -77,6 +95,7 @@ jobs:
             echo "retry status=${STATUS:-none} airports=${COUNT:-none}"
             numeric_or_fail
             if [ "${COUNT}" -lt "${MIN_AIRPORTS}" ]; then
+              dump_headers
               echo "::error::airports=${COUNT} still below floor ${MIN_AIRPORTS} after retry"
               exit 1
             fi

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -41,6 +41,10 @@ jobs:
               -H "apikey: ${SUPABASE_KEY}" \
               -H "Prefer: count=exact" \
               -H "Range: 0-0"
+            echo "curl_exit=$? key_len=${#SUPABASE_KEY}"
+            echo "--- raw response headers (responses carry no secrets) ---"
+            cat /tmp/headers
+            echo "--- end headers ---"
             STATUS=$(awk 'toupper($1) ~ /^HTTP/ {print $2}' /tmp/headers | tail -1)
             COUNT=$(tr -d '\r' < /tmp/headers |
               awk -F'/' 'tolower($0) ~ /^content-range:/ {print $2}')

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -2,13 +2,19 @@ name: Keep Supabase Active
 
 on:
   schedule:
-    # 12:00 UTC. daily-pipeline.yml runs at 11:30 UTC so its delete-then-insert
-    # window has normally closed before this check runs. That ordering is NOT
-    # guaranteed: GitHub delays scheduled runs under load, observed 1.5 to 2.5
-    # hours on this repository. The retry below is what actually prevents a false
-    # alarm, not the 30 minute offset.
+    # 12:00 UTC, two hours ahead of daily-pipeline.yml at 14:00 UTC, so this
+    # check normally runs well before that workflow's delete-then-insert window
+    # opens. That ordering is NOT guaranteed: GitHub delays scheduled runs under
+    # load, observed 1.5 to 2.5 hours on this repository, which is more than
+    # enough to reorder the two. The retry below is the actual protection against
+    # a false alarm, not the two hour gap.
     - cron: '0 12 * * *'
   workflow_dispatch: # Allow manual trigger
+
+# This job only reads a public REST endpoint. It never checks out the repository
+# and never writes anything, so it needs no token scope beyond the default read.
+permissions:
+  contents: read
 
 jobs:
   ping:

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The pipeline runs automatically via GitHub Actions.
 
 ### How It Works
 
-1. **Daily check** at 11:30 UTC - scrapes FAA website for current subscription date
+1. **Daily check** at 14:00 UTC - scrapes FAA website for current subscription date
 2. **Conditional execution** - full pipeline runs only when new data is available
 3. **Results** - written to GitHub Actions job summary (visible in workflow run page)
 4. **README auto-update** - commits updated counts and FAA date back to the repo

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The pipeline runs automatically via GitHub Actions.
 
 ### How It Works
 
-1. **Daily check** at 12:00 UTC - scrapes FAA website for current subscription date
+1. **Daily check** at 11:30 UTC - scrapes FAA website for current subscription date
 2. **Conditional execution** - full pipeline runs only when new data is available
 3. **Results** - written to GitHub Actions job summary (visible in workflow run page)
 4. **README auto-update** - commits updated counts and FAA date back to the repo


### PR DESCRIPTION
Does not close #38. That is a separate latent condition about `fs` and `cmake`.

## What changed

**`keep-alive.yml`**

1. **Key swap, the point of the change.** It pinged with `SUPABASE_API_KEY`, the
   write-capable secret key, for a read-only request. Now `SUPABASE_PUBLIC_KEY`.
   The publishable key is already public (`README.md` carries it eight times) and
   RLS grants `anon` SELECT on `airports`, so this reduces privilege with no
   functional change. Verified: the exact request returns **206** with the
   publishable key.
2. **Row count floor.** A status code alone cannot detect the failure that
   matters. A ranged request against an *empty* table answers successfully, so the
   old check would have reported "Supabase is active!" during
   `daily-pipeline.yml`'s delete-then-insert window with both tables empty. The
   check now asserts `airports >= 19000`, a floor rather than an exact count
   (observed cycle counts: 19410, 19408, 19436).
3. **One 60s retry behind the floor.** This distinguishes the pipeline's write
   window from a real outage. Necessary because GitHub delays scheduled runs under
   load, observed 1.5 to 2.5 hours on this repository, so a cron offset alone
   cannot reliably keep the two workflows apart.
4. **`timeout-minutes: 5`.** It previously inherited the 360 minute default.

**`daily-pipeline.yml`**

- Cron moved `0 12` to `30 11` UTC, so it normally completes before `keep-alive`
  queries row counts.
- Its concurrency comment named "12:00 UTC" and was updated. Leaving it would have
  been the same stale-reference defect this repository's `CONTRIBUTING.md`
  "Assertions in CI" section now warns about.

**`README.md`** one word: "Daily check at 12:00 UTC" to 11:30 UTC. Same reason.

## Non-obvious detail worth recording

PostgREST answers a ranged request with **206 Partial Content**, not 200. The
previous `if [ "$response" -ne 200 ]` check would have failed outright against a
`count=exact` request. Probed locally before writing it in:

```
content-range: 0-0/19436   HTTP/2 206
```

## Verification

- `ruby -ryaml` parses both workflows
- `lintr::lint_dir("R")` and `lintr::lint_dir("tests")`: **0 lints each**
- `testthat::test_dir("tests/testthat")`: **FAIL 0 | WARN 0 | SKIP 1 | PASS 124**,
  the skip pre-existing and gated on CRAN
- No R, test, or SQL changes. Three files, all workflow or documentation

Manual dispatch of both workflows from this branch to follow, per the request to
confirm the daily check still works.

---

## Root cause of the first failed dispatch, and the fix

The first dispatch of this branch failed. Recorded because the finding is reusable.

```
status=200 airports=*
##[error]Could not parse an exact row count from content-range
```

`200` instead of `206`, and `*` instead of a number, means **both** the
`Prefer: count=exact` and `Range: 0-0` headers were ignored while `apikey` still
authenticated. Instrumenting the run showed `key_len=47`; the clean publishable
key is 46 characters.

**Cause.** The `SUPABASE_PUBLIC_KEY` secret carries a trailing newline. A newline
inside a header value makes curl silently drop every *later* `-H`. Reproduced
locally:

| Key | Length | Result |
|-----|--------|--------|
| clean | 46 | `HTTP/2 206`, `content-range: 0-0/19436` |
| trailing newline | 47 | `HTTP/2 200`, `content-range: 0-999/*` |

**Fix.** Strip whitespace from the key before use, mirroring
`R/push_to_supabase.R`, which already trims `SUPABASE_API_KEY` with the comment
"whitespace/newlines that CI secrets handling may add". The repository had already
been bitten by this once.

An earlier attempt to rule whitespace out was invalid: `$(printf '%s\n' "$KEY")`
strips trailing newlines in command substitution, so it tested the clean key twice.

**Hardening carried forward.** The non-numeric count error now names whitespace in
the apikey as the likely cause, and raw response headers are dumped on failure
only. The next occurrence diagnoses itself.

The secret still has the newline; the workflow no longer cares. Re-setting it
cleanly is optional hygiene.

## Also included

`daily-pipeline.yml` input `default: 'false'` to `default: false`. Pre-existing
schema violation since 8c95fe8, unrelated to this branch, and the source of
Positron's `Incorrect type. Expected "boolean".` No behaviour change: the workflow
reads `github.event.inputs.force`, which the event payload delivers as a string
whatever the declared type.

## Runs on this branch

| Workflow | Run | Result |
|----------|-----|--------|
| CI | 30505741083 | success, 0 lints, 124 pass 1 skip |
| Keep Supabase Active | 30505641538 | success, `status=206 airports=19436` |
| Daily FAA Data Pipeline | 30505738870 | success, `Force Flag false`, `Already up to date (2026-07-09)`, no database write |
