### PR TITLE
fix(clean): read identifier columns as character, preserving SITE_NO

### DIFF
--- a/R/clean_airports.R
+++ b/R/clean_airports.R
@@ -9,6 +9,7 @@
 # run_cleaning.R too.
 #
 # Usage:
+#   source("R/parquet_schema.R")
 #   source("R/clean_airports.R")
 #   airports <- clean_airports("data/raw/19_DEC_2024_APT_CSV/APT_BASE.csv")
 
@@ -98,11 +99,12 @@ clean_airports <- function(apt_base_path) {
 
   # Verify required source columns exist before the full read: every pinned
   # colClasses name is a required column, so read.csv() cannot warn about a
-  # colClasses name missing from the file once this check passes.
+  # colClasses name missing from the file once this check passes. Reads only
+  # the first data row (nrows = 0 is ignored and would read the whole file).
   # FAA files use ISO-8859-1 (Latin-1) encoding for special characters.
   header <- names(read.csv(
     apt_base_path,
-    nrows = 0,
+    nrows = 1,
     fileEncoding = "ISO-8859-1",
     check.names = FALSE
   ))

--- a/R/clean_airports.R
+++ b/R/clean_airports.R
@@ -4,8 +4,9 @@
 # Companion to clean_navaids.R (navaids domain) and run_cleaning.R, which
 # holds the cleaning orchestration and the validate_cleaned_data() dispatcher
 # that delegates airports validation to validate_airports() defined here.
-# clean_airports() works standalone with only this file sourced; airports
-# validation through the dispatcher requires sourcing run_cleaning.R too.
+# clean_airports() requires parquet_schema.R (schema_col_classes()) to be
+# sourced; airports validation through the dispatcher requires sourcing
+# run_cleaning.R too.
 #
 # Usage:
 #   source("R/clean_airports.R")
@@ -95,16 +96,17 @@ clean_airports <- function(apt_base_path) {
 
   message("Reading airports from: ", apt_base_path)
 
-  # FAA files use ISO-8859-1 (Latin-1) encoding for special characters
-  airports_raw <- read.csv(
+  # Verify required source columns exist before the full read: every pinned
+  # colClasses name is a required column, so read.csv() cannot warn about a
+  # colClasses name missing from the file once this check passes.
+  # FAA files use ISO-8859-1 (Latin-1) encoding for special characters.
+  header <- names(read.csv(
     apt_base_path,
+    nrows = 0,
     fileEncoding = "ISO-8859-1",
-    stringsAsFactors = FALSE,
     check.names = FALSE
-  )
-
-  # Verify required source columns exist
-  missing_cols <- setdiff(airports_source_columns, names(airports_raw))
+  ))
+  missing_cols <- setdiff(airports_source_columns, header)
   if (length(missing_cols) > 0) {
     rlang::abort(
       c(
@@ -114,6 +116,25 @@ clean_airports <- function(apt_base_path) {
       class = "clean_data_schema_error"
     )
   }
+
+  # Pin STRING-declared columns as character so read.csv() cannot infer an
+  # all-digit SITE_NO as numeric and destroy leading zeros (issue #41).
+  # facility_use is derived (absent from the raw file); FACILITY_USE_CODE is
+  # raw-only.
+  col_classes <- c(
+    schema_col_classes(
+      airports_parquet_schema[names(airports_parquet_schema) != "facility_use"]
+    ),
+    FACILITY_USE_CODE = "character"
+  )
+
+  airports_raw <- read.csv(
+    apt_base_path,
+    fileEncoding = "ISO-8859-1",
+    stringsAsFactors = FALSE,
+    check.names = FALSE,
+    colClasses = col_classes
+  )
 
   # Map facility-use code to friendly label (fail loud on unknown code)
   airports_raw$facility_use <- map_facility_use(airports_raw$FACILITY_USE_CODE)
@@ -144,6 +165,18 @@ validate_airports <- function(data) {
   if (!"facility_use" %in% names(data)) {
     rlang::abort(
       "Column 'facility_use' is missing from airports data",
+      class = "validation_error"
+    )
+  }
+
+  # SITE_NO must be character: numeric inference destroys leading zeros and
+  # collides distinct FAA site numbers (error - critical)
+  if (!is.character(data$SITE_NO)) {
+    rlang::abort(
+      c(
+        paste("SITE_NO must be character, got", class(data$SITE_NO)[[1]]),
+        i = "clean_airports() pins SITE_NO via colClasses; check the read path"
+      ),
       class = "validation_error"
     )
   }

--- a/R/clean_navaids.R
+++ b/R/clean_navaids.R
@@ -3,9 +3,9 @@
 #
 # Companion to run_cleaning.R, which holds the cleaning orchestration
 # (run_cleaning(), the validate_cleaned_data() dispatcher, and the shared
-# raw-directory helpers). clean_navaids() works standalone with only this
-# file sourced; navaids validation through the dispatcher requires sourcing
-# run_cleaning.R too.
+# raw-directory helpers). clean_navaids() requires parquet_schema.R
+# (schema_col_classes()) to be sourced; navaids validation through the
+# dispatcher requires sourcing run_cleaning.R too.
 #
 # Usage:
 #   source("R/clean_navaids.R")
@@ -59,16 +59,17 @@ clean_navaids <- function(nav_base_path) {
 
   message("Reading navaids from: ", nav_base_path)
 
-  # FAA files use ISO-8859-1 (Latin-1) encoding for special characters
-  navaids_raw <- read.csv(
+  # Verify required columns exist before the full read: every pinned
+  # colClasses name is a required column, so read.csv() cannot warn about a
+  # colClasses name missing from the file once this check passes.
+  # FAA files use ISO-8859-1 (Latin-1) encoding for special characters.
+  header <- names(read.csv(
     nav_base_path,
+    nrows = 0,
     fileEncoding = "ISO-8859-1",
-    stringsAsFactors = FALSE,
     check.names = FALSE
-  )
-
-  # Verify required columns exist
-  missing_cols <- setdiff(navaids_columns, names(navaids_raw))
+  ))
+  missing_cols <- setdiff(navaids_columns, header)
   if (length(missing_cols) > 0) {
     rlang::abort(
       c(
@@ -78,6 +79,16 @@ clean_navaids <- function(nav_base_path) {
       class = "clean_data_schema_error"
     )
   }
+
+  # STRING-declared columns are pinned as character so an all-digit NAV_ID
+  # cannot be inferred as numeric (issue #41)
+  navaids_raw <- read.csv(
+    nav_base_path,
+    fileEncoding = "ISO-8859-1",
+    stringsAsFactors = FALSE,
+    check.names = FALSE,
+    colClasses = schema_col_classes(navaids_parquet_schema)
+  )
 
   navaids <- navaids_raw[, navaids_columns]
 

--- a/R/clean_navaids.R
+++ b/R/clean_navaids.R
@@ -8,6 +8,7 @@
 # dispatcher requires sourcing run_cleaning.R too.
 #
 # Usage:
+#   source("R/parquet_schema.R")
 #   source("R/clean_navaids.R")
 #   navaids <- clean_navaids("data/raw/19_DEC_2024_NAV_CSV/NAV_BASE.csv")
 
@@ -61,11 +62,12 @@ clean_navaids <- function(nav_base_path) {
 
   # Verify required columns exist before the full read: every pinned
   # colClasses name is a required column, so read.csv() cannot warn about a
-  # colClasses name missing from the file once this check passes.
+  # colClasses name missing from the file once this check passes. Reads only
+  # the first data row (nrows = 0 is ignored and would read the whole file).
   # FAA files use ISO-8859-1 (Latin-1) encoding for special characters.
   header <- names(read.csv(
     nav_base_path,
-    nrows = 0,
+    nrows = 1,
     fileEncoding = "ISO-8859-1",
     check.names = FALSE
   ))

--- a/R/parquet_schema.R
+++ b/R/parquet_schema.R
@@ -85,6 +85,23 @@ coerce_numeric <- function(x, type) {
   as.integer(converted)
 }
 
+#' Derive read.csv() colClasses from a Parquet schema
+#'
+#' Pins every STRING-declared column as character at read time, so read.csv()
+#' cannot infer an all-digit identifier (e.g. SITE_NO "00103.") as numeric and
+#' destroy leading zeros before the cleaning layer sees it. Non-STRING columns
+#' are left to inference; coerce_to_schema() pins those on the way out.
+#'
+#' @param schema Named character vector: column name to Parquet type
+#' @return Named character vector suitable for read.csv()'s colClasses
+#' @keywords internal
+schema_col_classes <- function(schema) {
+  checkmate::assert_character(schema, names = "named", any.missing = FALSE)
+
+  cols <- names(schema)[schema == "STRING"]
+  stats::setNames(rep("character", length(cols)), cols)
+}
+
 #' Coerce a cleaned data frame to its declared Parquet schema
 #'
 #' Pins types so the written Parquet file does not inherit read.csv()'s

--- a/R/push_to_supabase.R
+++ b/R/push_to_supabase.R
@@ -178,15 +178,23 @@ if (sys.nframe() == 0L) {
   # Script is being run directly (not sourced)
   message("Running push_to_supabase.R as main script...")
 
+  # Schemas drive colClasses so re-reading the clean CSVs cannot re-infer
+  # pinned identifier columns (e.g. site_no) as numeric (issue #41)
+  source("R/parquet_schema.R")
+  source("R/clean_airports.R")
+  source("R/clean_navaids.R")
+
   # Read clean data; convert column names to lowercase for Postgres
   message("Reading airports data...")
   airports <- read.csv("data/clean/airports.csv",
-                       stringsAsFactors = FALSE, check.names = FALSE)
+                       stringsAsFactors = FALSE, check.names = FALSE,
+                       colClasses = schema_col_classes(airports_parquet_schema))
   names(airports) <- tolower(names(airports))
 
   message("Reading navaids data...")
   navaids <- read.csv("data/clean/navaids.csv",
-                      stringsAsFactors = FALSE, check.names = FALSE)
+                      stringsAsFactors = FALSE, check.names = FALSE,
+                      colClasses = schema_col_classes(navaids_parquet_schema))
   names(navaids) <- tolower(names(navaids))
 
   # Clear and push airports

--- a/R/push_to_supabase.R
+++ b/R/push_to_supabase.R
@@ -187,14 +187,16 @@ if (sys.nframe() == 0L) {
   # Read clean data; convert column names to lowercase for Postgres
   message("Reading airports data...")
   airports <- read.csv("data/clean/airports.csv",
-                       stringsAsFactors = FALSE, check.names = FALSE,
-                       colClasses = schema_col_classes(airports_parquet_schema))
+    stringsAsFactors = FALSE, check.names = FALSE,
+    colClasses = schema_col_classes(airports_parquet_schema)
+  )
   names(airports) <- tolower(names(airports))
 
   message("Reading navaids data...")
   navaids <- read.csv("data/clean/navaids.csv",
-                      stringsAsFactors = FALSE, check.names = FALSE,
-                      colClasses = schema_col_classes(navaids_parquet_schema))
+    stringsAsFactors = FALSE, check.names = FALSE,
+    colClasses = schema_col_classes(navaids_parquet_schema)
+  )
   names(navaids) <- tolower(names(navaids))
 
   # Clear and push airports

--- a/tests/testthat/test-clean_airports.R
+++ b/tests/testthat/test-clean_airports.R
@@ -198,7 +198,7 @@ test_that("clean_airports preserves SITE_NO verbatim as character", {
   site_nos <- c("00103.", "00110.01", "14954.1", "14954.10")
   test_data <- data.frame(
     stringsAsFactors = FALSE,
-    EFF_DATE = "12/19/2024",
+    EFF_DATE = "2024/12/19",
     SITE_NO = site_nos,
     SITE_TYPE_CODE = "A",
     STATE_CODE = "CA",
@@ -228,11 +228,10 @@ test_that("validate_cleaned_data aborts when SITE_NO is not character", {
   names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
   data$SITE_NO <- seq_len(3)
 
+  # The SITE_NO abort is structural and fires before any warning, so no
+  # warning handling is needed here
   expect_error(
-    withCallingHandlers(
-      validate_cleaned_data(data, "airports"),
-      validation_warning = function(w) invokeRestart("muffleWarning")
-    ),
+    validate_cleaned_data(data, "airports"),
     class = "validation_error"
   )
 })

--- a/tests/testthat/test-clean_airports.R
+++ b/tests/testthat/test-clean_airports.R
@@ -1,8 +1,10 @@
 # test-clean_airports.R
 # Tests for R/clean_airports.R functions
 
-# clean_airports.R defines the airports functions; run_cleaning.R defines the
+# clean_airports.R defines the airports functions; parquet_schema.R provides
+# schema_col_classes() for the read-time pin; run_cleaning.R defines the
 # validate_cleaned_data() dispatcher that delegates to validate_airports().
+source_project_file("parquet_schema.R")
 source_project_file("clean_airports.R")
 source_project_file("run_cleaning.R")
 
@@ -187,6 +189,51 @@ test_that("clean_airports aborts on missing columns", {
   expect_error(
     clean_airports(temp_file),
     class = "clean_data_schema_error"
+  )
+})
+
+test_that("clean_airports preserves SITE_NO verbatim as character", {
+  temp_dir <- withr::local_tempdir()
+  temp_file <- file.path(temp_dir, "APT_BASE.csv")
+  site_nos <- c("00103.", "00110.01", "14954.1", "14954.10")
+  test_data <- data.frame(
+    stringsAsFactors = FALSE,
+    EFF_DATE = "12/19/2024",
+    SITE_NO = site_nos,
+    SITE_TYPE_CODE = "A",
+    STATE_CODE = "CA",
+    ARPT_ID = c("AAA1", "BBB1", "CCC1", "DDD1"),
+    CITY = "Test City", COUNTRY_CODE = "US", STATE_NAME = "California",
+    COUNTY_NAME = "Test County", ARPT_NAME = "Test Airport",
+    LAT_DEG = 33L, LAT_MIN = 56L, LAT_SEC = "33.00", LAT_HEMIS = "N",
+    LAT_DECIMAL = 33.94,
+    LONG_DEG = 118L, LONG_MIN = 24L, LONG_SEC = "29.00", LONG_HEMIS = "W",
+    LONG_DECIMAL = -118.41,
+    ELEV = 128, ELEV_METHOD_CODE = "S",
+    MAG_VARN = 13.0, MAG_HEMIS = "E", MAG_VARN_YEAR = 2020L,
+    ICAO_ID = "", FACILITY_USE_CODE = "PU"
+  )
+  write.csv(test_data, temp_file, row.names = FALSE)
+
+  expect_no_warning(result <- clean_airports(temp_file))
+
+  expect_type(result$SITE_NO, "character")
+  expect_identical(result$SITE_NO, site_nos)
+  expect_length(unique(result$SITE_NO), 4)
+})
+
+test_that("validate_cleaned_data aborts when SITE_NO is not character", {
+  data <- sample_airports(3)
+  names(data) <- toupper(names(data))
+  names(data)[names(data) == "FACILITY_USE"] <- "facility_use"
+  data$SITE_NO <- seq_len(3)
+
+  expect_error(
+    withCallingHandlers(
+      validate_cleaned_data(data, "airports"),
+      validation_warning = function(w) invokeRestart("muffleWarning")
+    ),
+    class = "validation_error"
   )
 })
 

--- a/tests/testthat/test-clean_navaids.R
+++ b/tests/testthat/test-clean_navaids.R
@@ -55,7 +55,7 @@ test_that("clean_navaids keeps an all-digit NAV_ID as character", {
 
   test_data <- data.frame(
     stringsAsFactors = FALSE,
-    EFF_DATE = "12/19/2024",
+    EFF_DATE = "2024/12/19",
     NAV_ID = c("090", "123"),
     NAV_TYPE = "VOR",
     STATE_CODE = "CA",

--- a/tests/testthat/test-clean_navaids.R
+++ b/tests/testthat/test-clean_navaids.R
@@ -1,8 +1,10 @@
 # test-clean_navaids.R
 # Tests for R/clean_navaids.R functions
 
-# clean_navaids.R defines the navaids functions; run_cleaning.R defines the
+# clean_navaids.R defines the navaids functions; parquet_schema.R provides
+# schema_col_classes() for the read-time pin; run_cleaning.R defines the
 # validate_cleaned_data() dispatcher that delegates to validate_navaids().
+source_project_file("parquet_schema.R")
 source_project_file("clean_navaids.R")
 source_project_file("run_cleaning.R")
 
@@ -45,6 +47,38 @@ test_that("clean_navaids returns expected columns", {
 
   expect_equal(sort(names(result)), sort(navaids_columns))
   expect_false("EXTRA_COL" %in% names(result))
+})
+
+test_that("clean_navaids keeps an all-digit NAV_ID as character", {
+  temp_dir <- withr::local_tempdir()
+  temp_file <- file.path(temp_dir, "NAV_BASE.csv")
+
+  test_data <- data.frame(
+    stringsAsFactors = FALSE,
+    EFF_DATE = "12/19/2024",
+    NAV_ID = c("090", "123"),
+    NAV_TYPE = "VOR",
+    STATE_CODE = "CA",
+    CITY = "Los Angeles",
+    COUNTRY_CODE = "US",
+    NAME = "Test VOR",
+    STATE_NAME = "California",
+    REGION_CODE = "AWP",
+    LAT_HEMIS = "N", LAT_DEG = 33L, LAT_MIN = 56L, LAT_SEC = "33.00",
+    LAT_DECIMAL = 33.94,
+    LONG_HEMIS = "W", LONG_DEG = 118L, LONG_MIN = 24L, LONG_SEC = "29.00",
+    LONG_DECIMAL = -118.41,
+    ELEV = 128,
+    MAG_VARN = 13.0, MAG_VARN_HEMIS = "E", MAG_VARN_YEAR = 2020L,
+    ALT_CODE = "LOW"
+  )
+
+  write.csv(test_data, temp_file, row.names = FALSE)
+
+  expect_no_warning(result <- clean_navaids(temp_file))
+
+  expect_type(result$NAV_ID, "character")
+  expect_identical(result$NAV_ID, c("090", "123"))
 })
 
 test_that("navaids validation warns on low row count", {

--- a/tests/testthat/test-run_cleaning.R
+++ b/tests/testthat/test-run_cleaning.R
@@ -124,6 +124,9 @@ test_that("run_cleaning cleans both datasets end to end", {
   expect_s3_class(apt_pq$EFF_DATE, "Date")
   expect_s3_class(nav_pq$EFF_DATE, "Date")
 
+  # Zero-padded FAA site numbers survive the read verbatim (issue #41)
+  expect_identical(apt_pq$SITE_NO, c("00001", "00002", "00003", "00004"))
+
   # Both validators ran: exactly the two row-count warnings, nothing else
   expect_length(warnings_seen, 2)
   expect_true(any(grepl("18000 airports", warnings_seen)))
@@ -160,6 +163,29 @@ test_that("coerce_to_schema aborts on an unsupported type", {
   expect_error(
     coerce_to_schema(data, c(arpt_id = "BLOB")),
     class = "clean_data_schema_type_error"
+  )
+})
+
+test_that("schema_col_classes pins STRING columns as character", {
+  schema <- c(A = "STRING", B = "INT32", C = "STRING", D = "DATE")
+
+  expect_identical(
+    schema_col_classes(schema),
+    c(A = "character", C = "character")
+  )
+})
+
+test_that("schema_col_classes returns an empty vector when nothing is STRING", {
+  result <- schema_col_classes(c(A = "INT32", B = "DOUBLE"))
+
+  expect_type(result, "character")
+  expect_length(result, 0)
+})
+
+test_that("schema_col_classes rejects an unnamed schema", {
+  expect_error(
+    schema_col_classes(c("STRING", "INT32")),
+    "Assertion on 'schema' failed"
   )
 })
 

--- a/tests/testthat/test-run_cleaning.R
+++ b/tests/testthat/test-run_cleaning.R
@@ -136,8 +136,10 @@ test_that("run_cleaning cleans both datasets end to end", {
 test_that("coerce_to_schema pins declared types", {
   data <- sample_airports(3)
   data$eff_date <- "2024/12/19"
-  schema <- c(eff_date = "DATE", arpt_id = "STRING", lat_deg = "INT32",
-              lat_decimal = "DOUBLE")
+  schema <- c(
+    eff_date = "DATE", arpt_id = "STRING", lat_deg = "INT32",
+    lat_decimal = "DOUBLE"
+  )
 
   result <- coerce_to_schema(data[names(schema)], schema)
 
@@ -292,7 +294,8 @@ test_that("write_clean_output rejects a non-data-frame", {
 
   expect_error(
     write_clean_output("not a data frame", "airports", fixture_schema(),
-                       dir = out_dir),
+      dir = out_dir
+    ),
     "Assertion on 'data' failed"
   )
 })
@@ -323,7 +326,8 @@ test_that("write_clean_output rejects a non-scalar name", {
 
   expect_error(
     write_clean_output(data, c("airports", "navaids"), fixture_schema(),
-                       dir = out_dir),
+      dir = out_dir
+    ),
     "Assertion on 'name' failed"
   )
 })


### PR DESCRIPTION
## Summary

Fixes #41. `read.csv()` without `colClasses` infers all-digit `SITE_NO` as numeric, destroying leading zeros and trailing periods (`00103.` -> `103`) and colliding two distinct FAA facility pairs (`14954.1`/`14954.10`, `27760.`/`27760.0`).

## Changes

- `schema_col_classes()` in `R/parquet_schema.R` derives `colClasses` from the pinned Parquet schemas, so every STRING-declared column is read as character. Read types and published types now share one source of truth.
- `clean_airports()` and `clean_navaids()` pin their raw reads. The required-columns check now runs against the header before the full read, so a missing pinned column aborts (`clean_data_schema_error`) without a `read.csv()` warning. The airports vector swaps derived `facility_use` for raw-only `FACILITY_USE_CODE`.
- `push_to_supabase.R` pins the clean-CSV re-reads in its main block (second inference point: a fixed `00103.` would otherwise be re-mangled on the manual push path).
- `validate_airports()` aborts (`validation_error`) if `SITE_NO` is not character.
- Regression tests: SITE_NO verbatim round-trip incl. both collision pairs, all-digit NAV_ID, end-to-end Parquet check, `schema_col_classes()` units, `expect_no_warning` on the read path.

## Evidence

New tests on unpatched main (before the fix):

```
FAILURE: Expected `result$SITE_NO` to have type "character". Actual type: "double"
FAILURE: Expected `unique(result$SITE_NO)` to have length 4. Actual length: 3.
FAILURE: `apt_pq$SITE_NO`: x[1]: "1"  y[1]: "00001"  (4/4 mismatches)
FAILURE: Expected `result$NAV_ID` to have type "character". Actual type: "integer"
```

With the fix: `[ FAIL 0 | WARN 0 | SKIP 1 | PASS 175 ]` (skip is the pre-existing on-CRAN skip). `lintr::lint_dir("R")` and `lint_dir("tests")`: no lints.

Verification against local raw (09_Jul_2026 revision, 19,436 rows):

```
raw distinct SITE_NO   : 19435
clean distinct SITE_NO : 19435   (was 19433)
00103. in clean csv    : TRUE
14954.10 in clean csv  : TRUE
27760.0 in clean csv   : TRUE
clean == raw verbatim  : TRUE
```

Old code vs new code on identical raw data: exactly one column differs — `SITE_NO`, 10,813 values regain their FAA form. All other airports columns and the entire navaids dataset are byte-identical. Per-column NA/empty-string counts are unchanged (no blank-field semantic shift from pinning).

## Data refresh (deliberately not in this PR)

Local `data/raw` is the stale 09_Jul cycle; CI already published the 06_Aug cycle (#40). Committing locally regenerated data would regress the dataset. After merge, a force run of the pipeline workflow re-downloads the current cycle, commits corrected clean data, and repopulates Supabase. Confirming with Mike before triggering, per the shared-DB coupling.

## Notes

- styler could not be run: not installed in the renv or user library. New code matches surrounding style; lintr is clean.
- Expect a large one-time `site_no` diff in `data/clean/airports.csv` on the next pipeline commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)